### PR TITLE
Remove legacy from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ Laravel MongoDB
 
 This package adds functionalities to the Eloquent model and Query builder for MongoDB, using the original Laravel API. *This library extends the original Laravel classes, so it uses exactly the same methods.*
 
+This package was renamed to `mongodb/laravel-mongodb` because of a transfer of ownership to MongoDB, Inc.
+It is compatible with Laravel 10.x. For older versions of Laravel, please refer to the [old versions](https://packagist.org/packages/jenssegers/mongodb).
+
 - [Laravel MongoDB](#laravel-mongodb)
     - [Installation](#installation)
-        - [Laravel version Compatibility](#laravel-version-compatibility)
-        - [Laravel](#laravel)
-        - [Lumen](#lumen)
-        - [Non-Laravel projects](#non-laravel-projects)
     - [Testing](#testing)
     - [Database Testing](#database-testing)
     - [Configuration](#configuration)
@@ -52,26 +51,7 @@ This package adds functionalities to the Eloquent model and Query builder for Mo
 Installation
 ------------
 
-Make sure you have the MongoDB PHP driver installed. You can find installation instructions at http://php.net/manual/en/mongodb.installation.php
-
-### Laravel version Compatibility
-
-| Laravel | Package        | Maintained         |
-| :------ | :------------- | :----------------- |
-| 9.x     | 3.9.x          | :white_check_mark: |
-| 8.x     | 3.8.x          | :white_check_mark: |
-| 7.x     | 3.7.x          | :x:                |
-| 6.x     | 3.6.x          | :x:                |
-| 5.8.x   | 3.5.x          | :x:                |
-| 5.7.x   | 3.4.x          | :x:                |
-| 5.6.x   | 3.4.x          | :x:                |
-| 5.5.x   | 3.3.x          | :x:                |
-| 5.4.x   | 3.2.x          | :x:                |
-| 5.3.x   | 3.1.x or 3.2.x | :x:                |
-| 5.2.x   | 2.3.x or 3.0.x | :x:                |
-| 5.1.x   | 2.2.x or 3.0.x | :x:                |
-| 5.0.x   | 2.1.x          | :x:                |
-| 4.2.x   | 2.0.x          | :x:                |
+Make sure you have the MongoDB PHP driver installed. You can find installation instructions at https://php.net/manual/en/mongodb.installation.php
 
 Install the package via Composer:
 
@@ -79,38 +59,10 @@ Install the package via Composer:
 $ composer require mongodb/laravel-mongodb
 ```
 
-### Laravel
-
 In case your Laravel version does NOT autoload the packages, add the service provider to `config/app.php`:
 
 ```php
 MongoDB\Laravel\MongodbServiceProvider::class,
-```
-
-### Lumen
-
-For usage with [Lumen](http://lumen.laravel.com), add the service provider in `bootstrap/app.php`. In this file, you will also need to enable Eloquent. You must however ensure that your call to `$app->withEloquent();` is **below** where you have registered the `MongodbServiceProvider`:
-
-```php
-$app->register(MongoDB\Laravel\MongodbServiceProvider::class);
-
-$app->withEloquent();
-```
-
-The service provider will register a MongoDB database extension with the original database manager. There is no need to register additional facades or objects.
-
-When using MongoDB connections, Laravel will automatically provide you with the corresponding MongoDB objects.
-
-### Non-Laravel projects
-
-For usage outside Laravel, check out the [Capsule manager](https://github.com/illuminate/database/blob/master/README.md) and add:
-
-```php
-$capsule->getDatabaseManager()->extend('mongodb', function($config, $name) {
-    $config['name'] = $name;
-
-    return new MongoDB\Laravel\Connection($config);
-});
 ```
 
 Testing


### PR DESCRIPTION
Link to the [`jenssegers/mongodb`](https://packagist.org/packages/jenssegers/mongodb) package for old versions.
[Lumen](https://lumen.laravel.com/docs/10.x) is deprecated.