### PR TITLE
Support delete one document with the query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,54 +19,55 @@ All notable changes to this project will be documented in this file.
 - Fix validation of unique values when the validated value is found as part of an existing value. [#21](https://github.com/GromNaN/laravel-mongodb/pull/21) by [@GromNaN](https://github.com/GromNaN).
 - Support `%` and `_` in `like` expression [#17](https://github.com/GromNaN/laravel-mongodb/pull/17) by [@GromNaN](https://github.com/GromNaN).
 - Change signature of `Query\Builder::__constructor` to match the parent class [#26](https://github.com/GromNaN/laravel-mongodb-private/pull/26) by [@GromNaN](https://github.com/GromNaN).
-- Fix Query on `whereDate`, `whereDay`, `whereMonth`, `whereYear`, `whereTime` to use MongoDB operators [#2570](https://github.com/jenssegers/laravel-mongodb/pull/2376) by [@Davpyu](https://github.com/Davpyu) and [@GromNaN](https://github.com/GromNaN).
-- `Model::unset()` does not persist the change. Call `Model::save()` to persist the change [#2578](https://github.com/jenssegers/laravel-mongodb/pull/2578) by [@GromNaN](https://github.com/GromNaN).
+- Fix Query on `whereDate`, `whereDay`, `whereMonth`, `whereYear`, `whereTime` to use MongoDB operators [#2570](https://github.com/mongodb/laravel-mongodb/pull/2376) by [@Davpyu](https://github.com/Davpyu) and [@GromNaN](https://github.com/GromNaN).
+- `Model::unset()` does not persist the change. Call `Model::save()` to persist the change [#2578](https://github.com/mongodb/laravel-mongodb/pull/2578) by [@GromNaN](https://github.com/GromNaN).
+- Support delete one document with `Query\Builder::limit(1)->delete()` [#2591](https://github.com/mongodb/laravel-mongodb/pull/2591) by [@GromNaN](https://github.com/GromNaN)
 
 ## [3.9.2] - 2022-09-01
 
 ### Added
-- Add single word name mutators [#2438](https://github.com/jenssegers/laravel-mongodb/pull/2438) by [@RosemaryOrchard](https://github.com/RosemaryOrchard) & [@mrneatly](https://github.com/mrneatly).
+- Add single word name mutators [#2438](https://github.com/mongodb/laravel-mongodb/pull/2438) by [@RosemaryOrchard](https://github.com/RosemaryOrchard) & [@mrneatly](https://github.com/mrneatly).
 
 ### Fixed
-- Fix stringable sort [#2420](https://github.com/jenssegers/laravel-mongodb/pull/2420) by [@apeisa](https://github.com/apeisa).
+- Fix stringable sort [#2420](https://github.com/mongodb/laravel-mongodb/pull/2420) by [@apeisa](https://github.com/apeisa).
 
 ## [3.9.1] - 2022-03-11
 
 ### Added
-- Backport support for cursor pagination [#2358](https://github.com/jenssegers/laravel-mongodb/pull/2358) by [@Jeroenwv](https://github.com/Jeroenwv).
+- Backport support for cursor pagination [#2358](https://github.com/mongodb/laravel-mongodb/pull/2358) by [@Jeroenwv](https://github.com/Jeroenwv).
 
 ### Fixed
-- Check if queue service is disabled [#2357](https://github.com/jenssegers/laravel-mongodb/pull/2357) by [@robjbrain](https://github.com/robjbrain).
+- Check if queue service is disabled [#2357](https://github.com/mongodb/laravel-mongodb/pull/2357) by [@robjbrain](https://github.com/robjbrain).
 
 ## [3.9.0] - 2022-02-17
 
 ### Added
-- Compatibility with Laravel 9.x [#2344](https://github.com/jenssegers/laravel-mongodb/pull/2344) by [@divine](https://github.com/divine).
+- Compatibility with Laravel 9.x [#2344](https://github.com/mongodb/laravel-mongodb/pull/2344) by [@divine](https://github.com/divine).
 
 ## [3.8.4] - 2021-05-27
 
 ### Fixed
-- Fix getRelationQuery breaking changes [#2263](https://github.com/jenssegers/laravel-mongodb/pull/2263) by [@divine](https://github.com/divine).
-- Apply fixes produced by php-cs-fixer [#2250](https://github.com/jenssegers/laravel-mongodb/pull/2250) by [@divine](https://github.com/divine).
+- Fix getRelationQuery breaking changes [#2263](https://github.com/mongodb/laravel-mongodb/pull/2263) by [@divine](https://github.com/divine).
+- Apply fixes produced by php-cs-fixer [#2250](https://github.com/mongodb/laravel-mongodb/pull/2250) by [@divine](https://github.com/divine).
 
 ### Changed
-- Add doesntExist to passthru [#2194](https://github.com/jenssegers/laravel-mongodb/pull/2194) by [@simonschaufi](https://github.com/simonschaufi).
-- Add Model query whereDate support [#2251](https://github.com/jenssegers/laravel-mongodb/pull/2251) by [@yexk](https://github.com/yexk).
-- Add transaction free deleteAndRelease() method [#2229](https://github.com/jenssegers/laravel-mongodb/pull/2229) by [@sodoardi](https://github.com/sodoardi).
-- Add setDatabase to Jenssegers\Mongodb\Connection [#2236](https://github.com/jenssegers/laravel-mongodb/pull/2236) by [@ThomasWestrelin](https://github.com/ThomasWestrelin).
-- Check dates against DateTimeInterface instead of DateTime [#2239](https://github.com/jenssegers/laravel-mongodb/pull/2239) by [@jeromegamez](https://github.com/jeromegamez).
-- Move from psr-0 to psr-4 [#2247](https://github.com/jenssegers/laravel-mongodb/pull/2247) by [@divine](https://github.com/divine).
+- Add doesntExist to passthru [#2194](https://github.com/mongodb/laravel-mongodb/pull/2194) by [@simonschaufi](https://github.com/simonschaufi).
+- Add Model query whereDate support [#2251](https://github.com/mongodb/laravel-mongodb/pull/2251) by [@yexk](https://github.com/yexk).
+- Add transaction free deleteAndRelease() method [#2229](https://github.com/mongodb/laravel-mongodb/pull/2229) by [@sodoardi](https://github.com/sodoardi).
+- Add setDatabase to Jenssegers\Mongodb\Connection [#2236](https://github.com/mongodb/laravel-mongodb/pull/2236) by [@ThomasWestrelin](https://github.com/ThomasWestrelin).
+- Check dates against DateTimeInterface instead of DateTime [#2239](https://github.com/mongodb/laravel-mongodb/pull/2239) by [@jeromegamez](https://github.com/jeromegamez).
+- Move from psr-0 to psr-4 [#2247](https://github.com/mongodb/laravel-mongodb/pull/2247) by [@divine](https://github.com/divine).
 
 ## [3.8.3] - 2021-02-21
 
 ### Changed
-- Fix query builder regression [#2204](https://github.com/jenssegers/laravel-mongodb/pull/2204) by [@divine](https://github.com/divine).
+- Fix query builder regression [#2204](https://github.com/mongodb/laravel-mongodb/pull/2204) by [@divine](https://github.com/divine).
 
 ## [3.8.2] - 2020-12-18
 
 ### Changed
-- MongodbQueueServiceProvider does not use the DB Facade anymore [#2149](https://github.com/jenssegers/laravel-mongodb/pull/2149) by [@curosmj](https://github.com/curosmj).
-- Add escape regex chars to DB Presence Verifier [#1992](https://github.com/jenssegers/laravel-mongodb/pull/1992) by [@andrei-gafton-rtgt](https://github.com/andrei-gafton-rtgt).
+- MongodbQueueServiceProvider does not use the DB Facade anymore [#2149](https://github.com/mongodb/laravel-mongodb/pull/2149) by [@curosmj](https://github.com/curosmj).
+- Add escape regex chars to DB Presence Verifier [#1992](https://github.com/mongodb/laravel-mongodb/pull/1992) by [@andrei-gafton-rtgt](https://github.com/andrei-gafton-rtgt).
 
 ## [3.8.1] - 2020-10-23
 
@@ -74,9 +75,9 @@ All notable changes to this project will be documented in this file.
 - Laravel 8 support by [@divine](https://github.com/divine).
 
 ### Changed
-- Fix like with numeric values [#2127](https://github.com/jenssegers/laravel-mongodb/pull/2127) by [@hnassr](https://github.com/hnassr).
+- Fix like with numeric values [#2127](https://github.com/mongodb/laravel-mongodb/pull/2127) by [@hnassr](https://github.com/hnassr).
 
 ## [3.8.0] - 2020-09-03
 
 ### Added
-- Laravel 8 support & updated versions of all dependencies [#2108](https://github.com/jenssegers/laravel-mongodb/pull/2108) by [@divine](https://github.com/divine).
+- Laravel 8 support & updated versions of all dependencies [#2108](https://github.com/mongodb/laravel-mongodb/pull/2108) by [@divine](https://github.com/divine).

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -703,7 +703,14 @@ class Builder extends BaseBuilder
         $wheres = $this->compileWheres();
         $options = $this->inheritConnectionOptions();
 
-        $result = $this->collection->deleteMany($wheres, $options);
+        if (is_int($this->limit)) {
+            if ($this->limit !== 1) {
+                throw new \LogicException(sprintf('Delete limit can be 1 or null (unlimited). Got %d', $this->limit));
+            }
+            $result = $this->collection->deleteOne($wheres, $options);
+        } else {
+            $result = $this->collection->deleteMany($wheres, $options);
+        }
 
         if (1 == (int) $result->isAcknowledged()) {
             return $result->getDeletedCount();

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -548,4 +548,40 @@ class QueryTest extends TestCase
         $this->assertEquals('John Doe', $subset[1]->name);
         $this->assertEquals('Brett Boe', $subset[2]->name);
     }
+
+    public function testDelete(): void
+    {
+        // Check fixtures
+        $this->assertEquals(3, User::where('title', 'admin')->count());
+
+        // Delete a single document with filter
+        User::where('title', 'admin')->limit(1)->delete();
+        $this->assertEquals(2, User::where('title', 'admin')->count());
+
+        // Delete all with filter
+        User::where('title', 'admin')->delete();
+        $this->assertEquals(0, User::where('title', 'admin')->count());
+
+        // Check remaining fixtures
+        $this->assertEquals(6, User::count());
+
+        // Delete a single document
+        User::limit(1)->delete();
+        $this->assertEquals(5, User::count());
+
+        // Delete all
+        User::limit(null)->delete();
+        $this->assertEquals(0, User::count());
+    }
+
+    /**
+     * @testWith [0]
+     *           [2]
+     */
+    public function testDeleteException(int $limit): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Delete limit can be 1 or null (unlimited).');
+        User::limit($limit)->delete();
+    }
 }


### PR DESCRIPTION
Fix #2502

MongoDB PHP Library supports deleting [one](https://github.com/mongodb/mongo-php-library/blob/a7a768252cc7509e8d5b053b3c90f799b2e55257/src/Operation/DeleteMany.php#L71) or [all](https://github.com/mongodb/mongo-php-library/blob/a7a768252cc7509e8d5b053b3c90f799b2e55257/src/Operation/DeleteMany.php#L71) documents only. So we cannot accept other limits than `null` (unlimited) or `1`.