### PR TITLE
Support IPv6 in host config

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -234,9 +234,17 @@ class Connection extends BaseConnection
         $hosts = is_array($config['host']) ? $config['host'] : [$config['host']];
 
         foreach ($hosts as &$host) {
-            // Check if we need to add a port to the host
-            if (strpos($host, ':') === false && ! empty($config['port'])) {
-                $host = $host.':'.$config['port'];
+            // ipv6
+            if (filter_var($host, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
+                $host = '['.$host.']';
+                if (! empty($config['port'])) {
+                    $host = $host.':'.$config['port'];
+                }
+            } else {
+                // Check if we need to add a port to the host
+                if (! str_contains($host, ':') && ! empty($config['port'])) {
+                    $host = $host.':'.$config['port'];
+                }
             }
         }
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -62,6 +62,54 @@ class ConnectionTest extends TestCase
             ],
         ];
 
+        yield 'IPv4' => [
+            'expectedUri' => 'mongodb://1.2.3.4',
+            'expectedDatabaseName' => 'tests',
+            'config' => [
+                'host' => '1.2.3.4',
+                'database' => 'tests',
+            ],
+        ];
+
+        yield 'IPv4 and port' => [
+            'expectedUri' => 'mongodb://1.2.3.4:1234',
+            'expectedDatabaseName' => 'tests',
+            'config' => [
+                'host' => '1.2.3.4',
+                'port' => 1234,
+                'database' => 'tests',
+            ],
+        ];
+
+        yield 'IPv6' => [
+            'expectedUri' => 'mongodb://[2001:db8:3333:4444:5555:6666:7777:8888]',
+            'expectedDatabaseName' => 'tests',
+            'config' => [
+                'host' => '2001:db8:3333:4444:5555:6666:7777:8888',
+                'database' => 'tests',
+            ],
+        ];
+
+        yield 'IPv6 and port' => [
+            'expectedUri' => 'mongodb://[2001:db8:3333:4444:5555:6666:7777:8888]:1234',
+            'expectedDatabaseName' => 'tests',
+            'config' => [
+                'host' => '2001:db8:3333:4444:5555:6666:7777:8888',
+                'port' => 1234,
+                'database' => 'tests',
+            ],
+        ];
+
+        yield 'multiple IPv6' => [
+            'expectedUri' => 'mongodb://[::1],[2001:db8::1:0:0:1]',
+            'expectedDatabaseName' => 'tests',
+            'config' => [
+                'host' => ['::1', '2001:db8::1:0:0:1'],
+                'port' => null,
+                'database' => 'tests',
+            ],
+        ];
+
         yield 'Port in host name takes precedence' => [
             'expectedUri' => 'mongodb://some-host:12345',
             'expectedDatabaseName' => 'tests',


### PR DESCRIPTION
Fix #2528 

Response from MongoDB AI chat (internal experimentation):
> To connect to an IPv6 server with the MongoDB PHP driver, you can specify the IPv6 address or hostname in the connection string. For example, if your server is listening on the IPv6 address `2001:0db8:85a3:0000:0000:8a2e:0370:7334` and port `27017`, you can use the following connection string:
>```
>mongodb://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:27017
>```
> Note that the IPv6 address must be enclosed in square brackets. For more information on connection strings, please refer to the "Connection String URI Format" section of the MongoDB PHP driver documentation in my knowledge.