### PR TITLE
Check if $primaryKey is present before execute unset

### DIFF
--- a/src/Relations/EmbedsMany.php
+++ b/src/Relations/EmbedsMany.php
@@ -152,7 +152,7 @@ class EmbedsMany extends EmbedsOneOrMany
 
         // Remove the document from the parent model.
         foreach ($records as $i => $record) {
-            if (in_array($record[$primaryKey], $ids)) {
+            if (array_key_exists($primaryKey, $record) && in_array($record[$primaryKey], $ids)) {
                 unset($records[$i]);
             }
         }

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -310,6 +310,21 @@ class EmbeddedRelationsTest extends TestCase
         $freshUser = User::find($user->id);
         $this->assertEquals(0, $user->addresses->count());
         $this->assertEquals(1, $freshUser->addresses->count());
+
+        $broken_address = Address::make(['name' => 'Broken']);
+
+        $user->update([
+            'addresses' => array_merge(
+                [$broken_address->toArray()],
+                $user->addresses()->toArray()
+            ),
+        ]);
+
+        $curitiba = $user->addresses()->create(['city' => 'Curitiba']);
+        $user->addresses()->dissociate($curitiba->id);
+
+        $this->assertEquals(1, $user->addresses->where('name', $broken_address->name)->count());
+        $this->assertEquals(1, $user->addresses->count());
     }
 
     public function testEmbedsManyAliases()


### PR DESCRIPTION
# Fix: Exception on Dissociate Operation for Embed Models in MongoDB

## Problem:
Previously, while executing a dissociate operation on Embed Models in MongoDB, an Exception was thrown that prevented the removal of Models. This happened specifically when a Model in the list lacked a **$propertyKey**.

## Solution:
This Pull Request adds a validation check to the dissociate operation for Embed Models in MongoDB. With this fix, the application will now verify if a propertyKey is present in each Model in the list before proceeding with the removal. This resolves the issue of an Exception being thrown during the operation.

## Testing
The fix has been thoroughly tested to ensure that the Exception no longer occurs. Now, a model will be successfully dissociated even if another model in the list lacks the **$propertyKey**.