### PR TITLE
Remove compatibility layers with old Laravel versions

### DIFF
--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -18,7 +18,6 @@ use MongoDB\Laravel\Relations\MorphTo;
 
 use function debug_backtrace;
 use function is_subclass_of;
-use function method_exists;
 
 use const DEBUG_BACKTRACE_IGNORE_ARGS;
 
@@ -322,20 +321,6 @@ trait HybridRelations
             $relatedKey ?: $instance->getKeyName(),
             $relation,
         );
-    }
-
-    /**
-     * Get the relationship name of the belongs to many.
-     *
-     * @return string
-     */
-    protected function guessBelongsToManyRelation()
-    {
-        if (method_exists($this, 'getBelongsToManyCaller')) {
-            return $this->getBelongsToManyCaller();
-        }
-
-        return parent::guessBelongsToManyRelation();
     }
 
     /** @inheritdoc */

--- a/src/Relations/BelongsTo.php
+++ b/src/Relations/BelongsTo.php
@@ -7,8 +7,6 @@ namespace MongoDB\Laravel\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
-use function property_exists;
-
 class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
 {
     /**
@@ -18,7 +16,7 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function getHasCompareKey()
     {
-        return $this->getOwnerKey();
+        return $this->ownerKey;
     }
 
     /** @inheritdoc */
@@ -28,7 +26,7 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $this->query->where($this->getOwnerKey(), '=', $this->parent->{$this->foreignKey});
+            $this->query->where($this->ownerKey, '=', $this->parent->{$this->foreignKey});
         }
     }
 
@@ -38,25 +36,13 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
         // We'll grab the primary key name of the related models since it could be set to
         // a non-standard name and not "id". We will then construct the constraint for
         // our eagerly loading query so it returns the proper models from execution.
-        $key = $this->getOwnerKey();
-
-        $this->query->whereIn($key, $this->getEagerModelKeys($models));
+        $this->query->whereIn($this->ownerKey, $this->getEagerModelKeys($models));
     }
 
     /** @inheritdoc */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
         return $query;
-    }
-
-    /**
-     * Get the owner key with backwards compatible support.
-     *
-     * @return string
-     */
-    public function getOwnerKey()
-    {
-        return property_exists($this, 'ownerKey') ? $this->ownerKey : $this->otherKey;
     }
 
     /**

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -18,7 +18,6 @@ use function array_values;
 use function count;
 use function is_array;
 use function is_numeric;
-use function property_exists;
 
 class BelongsToMany extends EloquentBelongsToMany
 {
@@ -123,7 +122,7 @@ class BelongsToMany extends EloquentBelongsToMany
         // First we need to attach any of the associated models that are not currently
         // in this joining table. We'll spin through the given IDs, checking to see
         // if they exist in the array of current ones, and if not we will insert.
-        $current = $this->parent->{$this->getRelatedKey()} ?: [];
+        $current = $this->parent->{$this->relatedPivotKey} ?: [];
 
         // See issue #256.
         if ($current instanceof Collection) {
@@ -196,7 +195,7 @@ class BelongsToMany extends EloquentBelongsToMany
         }
 
         // Attach the new ids to the parent model.
-        $this->parent->push($this->getRelatedKey(), (array) $id, true);
+        $this->parent->push($this->relatedPivotKey, (array) $id, true);
 
         if (! $touch) {
             return;
@@ -220,7 +219,7 @@ class BelongsToMany extends EloquentBelongsToMany
         $ids = (array) $ids;
 
         // Detach all ids from the parent model.
-        $this->parent->pull($this->getRelatedKey(), $ids);
+        $this->parent->pull($this->relatedPivotKey, $ids);
 
         // Prepare the query to select all related objects.
         if (count($ids) > 0) {
@@ -314,16 +313,6 @@ class BelongsToMany extends EloquentBelongsToMany
         }
 
         return $results;
-    }
-
-    /**
-     * Get the related key with backwards compatible support.
-     *
-     * @return string
-     */
-    public function getRelatedKey()
-    {
-        return property_exists($this, 'relatedPivotKey') ? $this->relatedPivotKey : $this->relatedKey;
     }
 
     /**

--- a/src/Relations/MorphTo.php
+++ b/src/Relations/MorphTo.php
@@ -7,8 +7,6 @@ namespace MongoDB\Laravel\Relations;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo as EloquentMorphTo;
 
-use function property_exists;
-
 class MorphTo extends EloquentMorphTo
 {
     /** @inheritdoc */
@@ -18,7 +16,7 @@ class MorphTo extends EloquentMorphTo
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $this->query->where($this->getOwnerKey(), '=', $this->parent->{$this->foreignKey});
+            $this->query->where($this->ownerKey, '=', $this->parent->{$this->foreignKey});
         }
     }
 
@@ -32,16 +30,6 @@ class MorphTo extends EloquentMorphTo
         $query = $instance->newQuery();
 
         return $query->whereIn($key, $this->gatherKeysByType($type, $instance->getKeyType()))->get();
-    }
-
-    /**
-     * Get the owner key with backwards compatible support.
-     *
-     * @return string
-     */
-    public function getOwnerKey()
-    {
-        return property_exists($this, 'ownerKey') ? $this->ownerKey : $this->otherKey;
     }
 
     /**


### PR DESCRIPTION
To make the library compatible with several major versions of Laravel, abstraction method had to be added by #1116 and [3e26e05b](https://github.com/mongodb/laravel-mongodb/commit/3e26e05b90cf5e207c66e30ea2021ff9ddb16bf9#diff-b815a7989006c7aaa05e7ccda0d141ca8adfa9c2d7d28bef4d38be00b772fd35R260-R267). They are no longer necessary.