### PR TITLE
PHPORM-90 Fix whereNot to use `$nor`

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1053,8 +1053,9 @@ class Builder extends BaseBuilder
             $method = 'compileWhere' . $where['type'];
             $result = $this->{$method}($where);
 
+            // Negate the expression
             if (str_ends_with($where['boolean'], 'not')) {
-                $result = ['$not' => $result];
+                $result = ['$nor' => [$result]];
             }
 
             // Wrap the where with an $or operator.

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -195,8 +195,8 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$and' => [
-                            ['$not' => ['name' => 'foo']],
-                            ['$not' => ['name' => ['$ne' => 'bar']]],
+                            ['$nor' => [['name' => 'foo']]],
+                            ['$nor' => [['name' => ['$ne' => 'bar']]]],
                         ],
                     ],
                     [], // options
@@ -231,8 +231,8 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['$not' => ['name' => 'foo']],
-                            ['$not' => ['name' => ['$ne' => 'bar']]],
+                            ['$nor' => [['name' => 'foo']]],
+                            ['$nor' => [['name' => ['$ne' => 'bar']]]],
                         ],
                     ],
                     [], // options
@@ -248,7 +248,7 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['$not' => ['name' => 'foo']],
+                            ['$nor' => [['name' => 'foo']]],
                             ['name' => ['$ne' => 'bar']],
                         ],
                     ],
@@ -264,7 +264,7 @@ class BuilderTest extends TestCase
         yield 'whereNot callable' => [
             [
                 'find' => [
-                    ['$not' => ['name' => 'foo']],
+                    ['$nor' => [['name' => 'foo']]],
                     [], // options
                 ],
             ],
@@ -278,7 +278,7 @@ class BuilderTest extends TestCase
                     [
                         '$and' => [
                             ['name' => 'bar'],
-                            ['$not' => ['email' => 'foo']],
+                            ['$nor' => [['email' => 'foo']]],
                         ],
                     ],
                     [], // options
@@ -295,10 +295,12 @@ class BuilderTest extends TestCase
             [
                 'find' => [
                     [
-                        '$not' => [
-                            '$and' => [
-                                ['name' => 'foo'],
-                                ['$not' => ['email' => ['$ne' => 'bar']]],
+                        '$nor' => [
+                            [
+                                '$and' => [
+                                    ['name' => 'foo'],
+                                    ['$nor' => [['email' => ['$ne' => 'bar']]]],
+                                ],
                             ],
                         ],
                     ],
@@ -318,7 +320,7 @@ class BuilderTest extends TestCase
                     [
                         '$or' => [
                             ['name' => 'bar'],
-                            ['$not' => ['email' => 'foo']],
+                            ['$nor' => [['email' => 'foo']]],
                         ],
                     ],
                     [], // options
@@ -337,7 +339,7 @@ class BuilderTest extends TestCase
                     [
                         '$or' => [
                             ['name' => 'bar'],
-                            ['$not' => ['email' => 'foo']],
+                            ['$nor' => [['email' => 'foo']]],
                         ],
                     ],
                     [], // options
@@ -353,10 +355,12 @@ class BuilderTest extends TestCase
             [
                 'find' => [
                     [
-                        '$not' => [
-                            '$and' => [
-                                ['foo' => 1],
-                                ['bar' => 2],
+                        '$nor' => [
+                            [
+                                '$and' => [
+                                    ['foo' => 1],
+                                    ['bar' => 2],
+                                ],
                             ],
                         ],
                     ],
@@ -371,10 +375,12 @@ class BuilderTest extends TestCase
             [
                 'find' => [
                     [
-                        '$not' => [
-                            '$and' => [
-                                ['foo' => 1],
-                                ['bar' => 2],
+                        '$nor' => [
+                            [
+                                '$and' => [
+                                    ['foo' => 1],
+                                    ['bar' => 2],
+                                ],
                             ],
                         ],
                     ],
@@ -389,10 +395,12 @@ class BuilderTest extends TestCase
             [
                 'find' => [
                     [
-                        '$not' => [
-                            '$and' => [
-                                ['foo' => 1],
-                                ['bar' => ['$lt' => 2]],
+                        '$nor' => [
+                            [
+                                '$and' => [
+                                    ['foo' => 1],
+                                    ['bar' => ['$lt' => 2]],
+                                ],
                             ],
                         ],
                     ],

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -170,12 +170,17 @@ class QueryTest extends TestCase
         $users = User::whereNot('title', '!=', 'admin')->get();
         $this->assertCount(3, $users);
 
+        // nested negation
+        $users = User::whereNot(fn (Builder $builder) => $builder
+            ->whereNot('title', 'admin'))->get();
+        $this->assertCount(3, $users);
+
         // explicit equality operator
         $users = User::whereNot('title', '=', 'admin')->get();
         $this->assertCount(6, $users);
 
         // custom query operator
-        $users = User::whereNot('title', ['$eq' => 'admin'])->get();
+        $users = User::whereNot('title', ['$in' => ['admin']])->get();
         $this->assertCount(6, $users);
 
         // regex

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -6,6 +6,8 @@ namespace MongoDB\Laravel\Tests;
 
 use DateTimeImmutable;
 use LogicException;
+use MongoDB\BSON\Regex;
+use MongoDB\Laravel\Eloquent\Builder;
 use MongoDB\Laravel\Tests\Models\Birthday;
 use MongoDB\Laravel\Tests\Models\Scoped;
 use MongoDB\Laravel\Tests\Models\User;
@@ -152,6 +154,43 @@ class QueryTest extends TestCase
 
         $this->assertEquals('John Doe', $user->name);
         $this->assertNull($user->age);
+    }
+
+    public function testWhereNot(): void
+    {
+        // implicit equality operator
+        $users = User::whereNot('title', 'admin')->get();
+        $this->assertCount(6, $users);
+
+        // nested query
+        $users = User::whereNot(fn (Builder $builder) => $builder->where('title', 'admin'))->get();
+        $this->assertCount(6, $users);
+
+        // double negation
+        $users = User::whereNot('title', '!=', 'admin')->get();
+        $this->assertCount(3, $users);
+
+        // explicit equality operator
+        $users = User::whereNot('title', '=', 'admin')->get();
+        $this->assertCount(6, $users);
+
+        // custom query operator
+        $users = User::whereNot('title', ['$eq' => 'admin'])->get();
+        $this->assertCount(6, $users);
+
+        // regex
+        $users = User::whereNot('title', new Regex('^admin$'))->get();
+        $this->assertCount(6, $users);
+
+        // equals null
+        $users = User::whereNot('title', null)->get();
+        $this->assertCount(8, $users);
+
+        // nested $or
+        $users = User::whereNot(fn (Builder $builder) => $builder
+            ->where('title', 'admin')
+            ->orWhere('age', 35))->get();
+        $this->assertCount(5, $users);
     }
 
     public function testOrWhere(): void


### PR DESCRIPTION
Fix #2623 #2418 [PHPORM-90](https://jira.mongodb.org/browse/PHPORM-90)

[`$not`](https://www.mongodb.com/docs/manual/reference/operator/query/not/) cannot be used with an expression. I switched to [`$nor`](https://www.mongodb.com/docs/manual/reference/operator/query/nor/), that negates a list of expressions.

The query could be optimized, but I expect the mongo server to be smart enough to do it.

Example of optimization I chose not to do because that would require to detect when there is a single field expression (related to https://github.com/GromNaN/laravel-mongodb/pull/13#discussion_r1268289478)

This expression:
```ts
{ field: { operator: value } }
```

Is negated with:
```ts
{ $nor: [ { field: { operator: value } } ] }
```
While it could also be:
```ts
{ field: { $not: { operator: value } }
```