### PR TITLE
PHPLARA-249 support automated embedding in vectorSearch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Create a free VoyageAI API Key on https://dashboard.voyageai.com/organization/api-keys
+VOYAGE_API_KEY=

--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Create MongoDB Atlas Local
         timeout-minutes: 5
         run: |
-          docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:latest
+          docker run --name mongodb -p 27017:27017 \
+              -e VOYAGE_API_KEY=${{ secrets.VOYAGE_API_KEY }} \
+              -e EMBEDDING_PROVIDER_ENDPOINT=https://api.voyageai.com/v1/embeddings \
+              --detach mongodb/mongodb-atlas-local:latest
           until docker exec --tty mongodb mongosh --eval "db.hello().isWritablePrimary" | grep -q true; do sleep 1; done
           until docker exec --tty mongodb mongosh --eval "db.getCollection('connection_test').insertOne({})"; do sleep 1; done
           until docker exec --tty mongodb mongosh --eval "db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do sleep 1; done

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.sublime-workspace
 .DS_Store
 .idea/
+.env
 /vendor
 composer.lock
 composer.phar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,12 @@ services:
         image: mongodb/mongodb-atlas-local:8
         ports:
             - "27017:27017"
+        env_file:
+            - path: .env
+              required: false
+        environment:
+            VOYAGE_API_KEY: ${VOYAGE_API_KEY:-}
+            EMBEDDING_PROVIDER_ENDPOINT: ${EMBEDDING_PROVIDER_ENDPOINT:-https://api.voyageai.com/v1/embeddings}
         healthcheck:
             test: mongosh --quiet --eval 'db.runCommand("ping").ok'
             interval: 10s

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,6 +25,13 @@ parameters:
             path: src/MongoDBServiceProvider.php
             count: 1
             reportUnmatched: false
+        # The "query" and "model" parameters of vectorSearch() require mongodb/mongodb 2.4+,
+        # not yet available in the version currently installed.
+        -
+            identifier: argument.unknown
+            path: src/Query/Builder.php
+            count: 2
+            reportUnmatched: false
 
 services:
     errorFormatter.sarif:

--- a/resources/boost/skills/laravel-mongodb/references/vector-search.md
+++ b/resources/boost/skills/laravel-mongodb/references/vector-search.md
@@ -67,24 +67,16 @@ Product::create([
 
 use App\Models\Product;
 
-$results = Product::raw(fn ($c) => $c->aggregate([
-    ['$vectorSearch' => [
-        'index'         => 'products_vector',
-        'path'          => 'description',
-        'queryText'     => 'noise-cancelling headphones for travel',
-        'numCandidates' => 100,
-        'limit'         => 10,
-    ]],
-    ['$project' => [
-        'name'        => 1,
-        'description' => 1,
-        'price'       => 1,
-        'score'       => ['$meta' => 'vectorSearchScore'],
-    ]],
-]));
+$results = Product::vectorSearch(
+    index: 'products_vector',
+    path: 'description',
+    query: 'noise-cancelling headphones for travel',
+    numCandidates: 100,
+    limit: 10,
+);
 ```
 
-Use `queryText` (string) when the index uses `autoEmbed`. Use `queryVector` (float array) when providing vectors manually.
+Pass `query` (string) when the index uses `autoEmbed`; pass `queryVector` (float array) when providing vectors manually. The optional `model` parameter overrides the model configured on the index.
 
 ## Manual embedding
 

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -122,13 +122,25 @@ class Builder extends EloquentBuilder
     public function vectorSearch(
         string $index,
         string $path,
-        array $queryVector,
-        int $limit,
+        array|null $queryVector = null,
+        int $limit = 10,
         bool $exact = false,
         QueryInterface|array $filter = [],
         int|null $numCandidates = null,
+        string|null $query = null,
+        string|null $model = null,
     ): Collection {
-        $results = $this->toBase()->vectorSearch($index, $path, $queryVector, $limit, $exact, $filter, $numCandidates);
+        $results = $this->toBase()->vectorSearch(
+            index: $index,
+            path: $path,
+            limit: $limit,
+            queryVector: $queryVector,
+            exact: $exact,
+            filter: $filter,
+            numCandidates: $numCandidates,
+            query: $query,
+            model: $model,
+        );
 
         return $this->model->hydrate($results->all());
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1696,21 +1696,25 @@ class Builder extends BaseBuilder
     public function vectorSearch(
         string $index,
         string $path,
-        array $queryVector,
-        int $limit,
+        array|null $queryVector = null,
+        int $limit = 10,
         bool $exact = false,
         QueryInterface|array|null $filter = null,
         int|null $numCandidates = null,
+        string|null $query = null,
+        string|null $model = null,
     ): Collection {
         // Forward named arguments to the vectorSearch stage, skip null values
         $args = array_filter([
             'index' => $index,
             'limit' => $limit,
             'path' => $path,
-            'queryVector' => $queryVector,
+            'model' => $model,
             'exact' => $exact,
             'filter' => $filter,
             'numCandidates' => $numCandidates,
+            'queryVector' => $queryVector,
+            'query' => $query,
         ], fn ($arg) => $arg !== null);
 
         return $this->aggregate()

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -28,6 +28,7 @@ use MongoDB\Driver\Cursor;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Laravel\Connection;
 use Override;
+use ReflectionMethod;
 use RuntimeException;
 use SortDirection;
 use TypeError;
@@ -1704,6 +1705,10 @@ class Builder extends BaseBuilder
         string|null $query = null,
         string|null $model = null,
     ): Collection {
+        if (($query !== null || $model !== null) && ! self::vectorSearchSupportsAutoEmbedding()) {
+            throw new BadMethodCallException('The "query" and "model" parameters of vectorSearch() require mongodb/mongodb 2.4+.');
+        }
+
         // Forward named arguments to the vectorSearch stage, skip null values
         $args = array_filter([
             'index' => $index,
@@ -1744,6 +1749,28 @@ class Builder extends BaseBuilder
         return $this->aggregate()->search(
             Search::autocomplete(...$args),
         )->get()->pluck($path);
+    }
+
+    /**
+     * Check whether the installed mongodb/mongodb library supports the
+     * "query" and "model" auto-embedding parameters of vectorSearch(),
+     * added in mongodb/mongodb 2.4.
+     */
+    private static function vectorSearchSupportsAutoEmbedding(): bool
+    {
+        static $supported;
+
+        if ($supported === null) {
+            $supported = false;
+            foreach ((new ReflectionMethod(FluentFactoryTrait::class, 'vectorSearch'))->getParameters() as $param) {
+                if ($param->getName() === 'query') {
+                    $supported = true;
+                    break;
+                }
+            }
+        }
+
+        return $supported;
     }
 
     /**

--- a/tests/AtlasSearchIndexManagement.php
+++ b/tests/AtlasSearchIndexManagement.php
@@ -32,9 +32,9 @@ trait AtlasSearchIndexManagement
     /**
      * Waits for all search indexes to be ready
      */
-    public function waitForSearchIndexesReady(Collection $collection)
+    public function waitForSearchIndexesReady(Collection $collection, int $timeoutSeconds = 120)
     {
-        $timeout = hrtime()[0] + 120;
+        $timeout = hrtime()[0] + $timeoutSeconds;
         do {
             if (hrtime()[0] > $timeout) {
                 throw new RuntimeException('Timed out waiting for search indexes to be ready');

--- a/tests/AtlasSearchTest.php
+++ b/tests/AtlasSearchTest.php
@@ -15,10 +15,12 @@ use PHPUnit\Framework\Attributes\Group;
 
 use function array_map;
 use function assert;
+use function getenv;
 use function mt_getrandmax;
 use function rand;
 use function range;
 use function srand;
+use function str_contains;
 use function usort;
 
 #[Group('atlas-search')]
@@ -246,6 +248,49 @@ class AtlasSearchTest extends TestCase
             $results->first()->vectorSearchScore,
             self::logicalAnd(self::isType('float'), self::greaterThan(0.9), self::lessThan(1.0)),
         );
+    }
+
+    public function testEloquentBuilderVectorSearchAutoEmbedding()
+    {
+        if (getenv('VOYAGE_API_KEY') === false || getenv('VOYAGE_API_KEY') === '') {
+            self::markTestSkipped('Auto embedding requires VOYAGE_API_KEY to be set on the Atlas cluster.');
+        }
+
+        $collection = $this->getConnection('mongodb')->getCollection('books');
+        assert($collection instanceof MongoDBCollection);
+
+        try {
+            Schema::table('books', function ($table) {
+                $table->vectorSearchIndex([
+                    'fields' => [
+                        ['type' => 'autoEmbed', 'modality' => 'text', 'path' => 'title', 'model' => 'voyage-4-large'],
+                    ],
+                ], 'auto_embed');
+            });
+        } catch (ServerException $e) {
+            if (str_contains($e->getMessage(), 'not registered')) {
+                self::markTestSkipped('Auto embedding requires an Atlas cluster with a registered embedding model. Set VOYAGE_API_KEY.');
+            }
+
+            throw $e;
+        }
+
+        $this->waitForSearchIndexesReady($collection);
+
+        // Query with a lighter model (voyage-4-lite) than the indexing model (voyage-4-large);
+        // all voyage-4 embeddings are compatible.
+        $results = Book::vectorSearch(
+            index: 'auto_embed',
+            path: 'title',
+            query: 'machine learning textbook',
+            model: 'voyage-4-lite',
+            limit: 3,
+        );
+
+        self::assertInstanceOf(EloquentCollection::class, $results);
+        self::assertCount(3, $results);
+        self::assertInstanceOf(Book::class, $results->first());
+        self::assertIsFloat($results->first()->vectorSearchScore);
     }
 
     /** Generate random vectors using fixed seed to make tests deterministic */


### PR DESCRIPTION
Adds support for [automated embedding generation](https://www.mongodb.com/docs/atlas/atlas-vector-search/automated-vector-search/) in `$vectorSearch` by exposing the new `query` and `model` parameters. When using an Atlas Vector Search index with an embedding model configured, callers can now pass a raw text `query` (and optional `model`) instead of pre-computing a `queryVector`.

- `queryVector` becomes optional; `query` / `model` are forwarded to the `\$vectorSearch` stage
- `limit` defaults to 10 to allow calling with only `query`
- Refs [PHPLARA-249](https://jira.mongodb.org/browse/PHPLARA-249)