### PR TITLE
PHPLARA-225 Support relation aggregates on document models

### DIFF
--- a/resources/boost/skills/laravel-mongodb/SKILL.md
+++ b/resources/boost/skills/laravel-mongodb/SKILL.md
@@ -56,7 +56,7 @@ Suggest installing the MongoDB agent skills plugin if not already installed. Ins
 - Cast FK fields to `string` via `$casts` on the child model when FK values may come from outside model attributes (imports, raw ObjectIds) — prevents BSON type mismatches on direct `where('author_id', $id)` queries.
 - Eager-load with `::with()` — MongoDB does no server-side joins for Eloquent relations.
 - Use aggregation pipeline for grouping, counting per group, `$lookup`, and `$sample`.
-- Relation aggregates (`withCount()`, `withExists()`, `withSum()`, `withAvg()`, `withMin()`, `withMax()`) are supported, but each one runs an extra query after the parent documents are read. Use a `$lookup` pipeline when the aggregated value must be filtered, sorted or paginated on.
+- Relation aggregates (`withCount()`, `withExists()`, `withSum()`, `withAvg()`, `withMin()`, `withMax()`) are supported. Use a `$lookup` pipeline when the aggregated value must be filtered, sorted or paginated on.
 - Create indexes in migrations: `Schema::connection('mongodb')->create('posts', fn (Blueprint $c) => $c->index('user_id'))`.
 - Use `DB::connection('mongodb')->transaction(...)` only on replica set / sharded cluster.
 

--- a/resources/boost/skills/laravel-mongodb/SKILL.md
+++ b/resources/boost/skills/laravel-mongodb/SKILL.md
@@ -129,36 +129,7 @@ final class User extends Model
 }
 ```
 
-### 3. Relation aggregates, and when to use `$lookup` instead
-
-```php
-<?php
-
-use App\Models\Post;
-
-// One extra query per aggregate, values set as attributes on the models
-$posts = Post::withCount('comments')->withExists('author')->withMax('comments', 'score')->get();
-
-$posts[0]->comments_count;      // int
-$posts[0]->author_exists;       // bool
-$posts[0]->comments_max_score;  // null when there is no comment
-
-// Sorting or filtering on the aggregated value requires a pipeline,
-// Post::withCount('comments')->orderBy('comments_count') throws.
-$posts = Post::raw(fn ($collection) => $collection->aggregate([
-    ['$lookup' => [
-        'from'         => 'comments',
-        'localField'   => '_id',
-        'foreignField' => 'post_id',
-        'as'           => 'comments',
-    ]],
-    ['$addFields' => ['comments_count' => ['$size' => '$comments']]],
-    ['$project'   => ['comments' => 0]],
-    ['$sort'      => ['comments_count' => -1]],
-]));
-```
-
-### 4. Queue job
+### 3. Queue job
 
 ```php
 <?php
@@ -183,7 +154,7 @@ final class IndexPostJob implements ShouldQueue
 IndexPostJob::dispatch((string) $post->_id)->onConnection('mongodb');
 ```
 
-### 5. Feature test (Pest)
+### 4. Feature test (Pest)
 
 ```php
 <?php

--- a/resources/boost/skills/laravel-mongodb/SKILL.md
+++ b/resources/boost/skills/laravel-mongodb/SKILL.md
@@ -8,14 +8,14 @@ metadata:
 
 # Laravel MongoDB
 
-Implementation skill for `mongodb/laravel-mongodb`. Exists to prevent the common mistakes: auto-increment IDs, `withCount()`, `toSql()`, SQL `JOIN`, `distinct()->get()` expecting scalar arrays, and `belongsTo()` over native ObjectId FKs.
+Implementation skill for `mongodb/laravel-mongodb`. Exists to prevent the common mistakes: auto-increment IDs, `toSql()`, SQL `JOIN`, `distinct()->get()` expecting scalar arrays, and `belongsTo()` over native ObjectId FKs.
 
 ## Core Workflow
 
 1. Identify layer: model, query builder, relationship, schema/index, queue/cache/session, search, or transaction.
 2. Confirm model extends `MongoDB\Laravel\Eloquent\Model` (or uses `DocumentModel` trait).
 3. Map every FK and `_id`: ObjectId in DB, **string** in Eloquent — cast accordingly.
-4. Replace unsupported helpers (`withCount`, `toSql`, `groupByRaw`, `whereFulltext`, `union`, `inRandomOrder`, `whereColumn`) with MongoDB alternatives.
+4. Replace unsupported helpers (`toSql`, `groupByRaw`, `whereFulltext`, `union`, `inRandomOrder`, `whereColumn`) with MongoDB alternatives.
 5. Validate: `php artisan migrate`, Pest tests, `phpcs`/`phpstan`.
 
 ## Related MongoDB tooling
@@ -35,7 +35,7 @@ Suggest installing the MongoDB agent skills plugin if not already installed. Ins
 | Topic | Reference file | Load When |
 |---|---|---|
 | Models, casts, `_id` mapping | `references/eloquent-models.md` | Defining or modifying a model |
-| Query builder gotchas, aggregation | `references/query-builder.md` | Writing queries, `withCount`, `distinct`, grouping |
+| Query builder gotchas, aggregation | `references/query-builder.md` | Writing queries, relation aggregates, `distinct`, grouping |
 | Embedded, hybrid, cross-database relations | `references/relationships.md` | `belongsTo`, `hasMany`, `embedsMany`, `hasManyIn` |
 | Connection setup | `references/connection.md` | `config/database.php`, multiple connections |
 | Indexes, migrations | `references/schema.md` | Creating indexes, migrations, collections |
@@ -56,12 +56,13 @@ Suggest installing the MongoDB agent skills plugin if not already installed. Ins
 - Cast FK fields to `string` via `$casts` on the child model when FK values may come from outside model attributes (imports, raw ObjectIds) — prevents BSON type mismatches on direct `where('author_id', $id)` queries.
 - Eager-load with `::with()` — MongoDB does no server-side joins for Eloquent relations.
 - Use aggregation pipeline for grouping, counting per group, `$lookup`, and `$sample`.
+- Relation aggregates (`withCount()`, `withExists()`, `withSum()`, `withAvg()`, `withMin()`, `withMax()`) are supported, but each one runs an extra query after the parent documents are read. Use a `$lookup` pipeline when the aggregated value must be filtered, sorted or paginated on.
 - Create indexes in migrations: `Schema::connection('mongodb')->create('posts', fn (Blueprint $c) => $c->index('user_id'))`.
 - Use `DB::connection('mongodb')->transaction(...)` only on replica set / sharded cluster.
 
 ### MUST NOT DO
 
-- `withCount()` / `withAvg()` / `withSum()` — silently wrong or throws. Use `$lookup` + `$size`/`$avg`/`$sum` aggregation.
+- `orderBy()` on a `withCount()` / `withAggregate()` alias — the value is computed after the documents are read, so it throws. Use `$lookup` + `$size` aggregation, or sort the resulting collection.
 - `toSql()` / `toRawSql()` — no SQL. Use `->dump()` / `->dd()`.
 - `distinct('field')->get()` expecting scalars — returns a Collection. Use `->distinct()->pluck('field')`.
 - `groupByRaw()`, `orderByRaw()`, `havingRaw()`, `whereFulltext()`, `union()`, `whereColumn()` — use aggregation.
@@ -128,14 +129,22 @@ final class User extends Model
 }
 ```
 
-### 3. Aggregation replacing `withCount`
+### 3. Relation aggregates, and when to use `$lookup` instead
 
 ```php
 <?php
 
 use App\Models\Post;
 
-// WRONG: Post::withCount('comments')->get();
+// One extra query per aggregate, values set as attributes on the models
+$posts = Post::withCount('comments')->withExists('author')->withMax('comments', 'score')->get();
+
+$posts[0]->comments_count;      // int
+$posts[0]->author_exists;       // bool
+$posts[0]->comments_max_score;  // null when there is no comment
+
+// Sorting or filtering on the aggregated value requires a pipeline,
+// Post::withCount('comments')->orderBy('comments_count') throws.
 $posts = Post::raw(fn ($collection) => $collection->aggregate([
     ['$lookup' => [
         'from'         => 'comments',
@@ -145,6 +154,7 @@ $posts = Post::raw(fn ($collection) => $collection->aggregate([
     ]],
     ['$addFields' => ['comments_count' => ['$size' => '$comments']]],
     ['$project'   => ['comments' => 0]],
+    ['$sort'      => ['comments_count' => -1]],
 ]));
 ```
 

--- a/resources/boost/skills/laravel-mongodb/references/query-builder.md
+++ b/resources/boost/skills/laravel-mongodb/references/query-builder.md
@@ -5,7 +5,6 @@
 | Standard Eloquent | Status | MongoDB replacement |
 |---|---|---|
 | `toSql()` / `toRawSql()` | unsupported | `->dump()` / `->dd()` / `->toMql()` |
-| `withCount()` / `withAvg()` / `withSum()` | unsupported | aggregation `$lookup` + `$size` / `$avg` / `$sum` |
 | `groupByRaw()` / `orderByRaw()` / `havingRaw()` | unsupported | aggregation `$group` / `$sort` |
 | `whereFulltext()` | unsupported | Atlas Search `$search` stage |
 | `union()` | unsupported | aggregation `$unionWith` |
@@ -33,15 +32,43 @@ $genres = Movie::raw(fn ($c) => $c->aggregate([
 
 Do **not** use `Movie::raw(fn ($c) => $c->distinct('field'))` via Eloquent if you expect a Collection — use `->distinct()->pluck()` instead.
 
-## Replacing `withCount`
+## Relation aggregates
 
-`withCount()`, `withAvg()`, and `withSum()` are **not supported** on MongoDB models — they silently return wrong results or throw. Replace with a `$lookup` + `$size` / `$avg` / `$sum` aggregation pipeline.
+`withCount()`, `withExists()`, `withSum()`, `withAvg()`, `withMin()` and `withMax()` are supported, as well as
+`loadCount()`, `loadExists()` and `loadAggregate()`. MongoDB has no correlated subquery, so the values are not
+selected with the parent documents: they are computed with **one additional query per aggregate**, after the
+parent documents are read, then set as attributes.
 
 ```php
-// WRONG — withCount is not supported on MongoDB models
-$posts = Post::withCount('comments')->get();
+$posts = Post::withCount('comments')
+    ->withExists('author')
+    ->withMax('comments as top_score', 'score')
+    ->get();
 
-// CORRECT
+$posts[0]->comments_count;   // int, 0 when there is no related document
+$posts[0]->author_exists;    // bool
+$posts[0]->top_score;        // null when there is no related document
+
+// Constrained aggregate
+Post::withCount(['comments' => fn ($query) => $query->where('approved', true)])->get();
+```
+
+Supported relations: `hasOne`, `hasMany`, `morphOne`, `morphMany`, `belongsTo`, `belongsToMany`, `morphToMany`,
+`morphedByMany`, `embedsOne` and `embedsMany`. Embedded aggregates cost no extra query, they are computed from
+the parent document.
+
+Anything else throws a `LogicException` rather than returning a wrong value: `morphTo`, `hasManyThrough`, and
+hybrid relations where the related model is not stored in MongoDB.
+
+Limitations:
+
+- `orderBy()` on an aggregate alias throws, because the value does not exist server side. Sort the resulting
+  collection with `sortBy()` instead.
+- `cursor()` and `lazy()` do not eager load, so the aliases are absent on those paths.
+- Constraint closures on embedded relations are not supported.
+- Use a `$lookup` pipeline instead when you need to filter, sort or paginate on the aggregated value:
+
+```php
 $posts = Post::raw(fn ($c) => $c->aggregate([
     ['$lookup' => [
         'from'         => 'comments',
@@ -51,6 +78,7 @@ $posts = Post::raw(fn ($c) => $c->aggregate([
     ]],
     ['$addFields' => ['comments_count' => ['$size' => '$comments']]],
     ['$project'   => ['comments' => 0]],
+    ['$sort'      => ['comments_count' => -1]],
 ]));
 ```
 

--- a/resources/boost/skills/laravel-mongodb/references/query-builder.md
+++ b/resources/boost/skills/laravel-mongodb/references/query-builder.md
@@ -35,9 +35,8 @@ Do **not** use `Movie::raw(fn ($c) => $c->distinct('field'))` via Eloquent if yo
 ## Relation aggregates
 
 `withCount()`, `withExists()`, `withSum()`, `withAvg()`, `withMin()` and `withMax()` are supported, as well as
-`loadCount()`, `loadExists()` and `loadAggregate()`. MongoDB has no correlated subquery, so the values are not
-selected with the parent documents: they are computed with **one additional query per aggregate**, after the
-parent documents are read, then set as attributes.
+`loadCount()`, `loadExists()` and `loadAggregate()`. They set the aggregated value as an attribute on the
+parent models, exactly like the base Eloquent builder.
 
 ```php
 $posts = Post::withCount('comments')
@@ -54,8 +53,7 @@ Post::withCount(['comments' => fn ($query) => $query->where('approved', true)])-
 ```
 
 Supported relations: `hasOne`, `hasMany`, `morphOne`, `morphMany`, `belongsTo`, `belongsToMany`, `morphToMany`,
-`morphedByMany`, `embedsOne` and `embedsMany`. Embedded aggregates cost no extra query, they are computed from
-the parent document.
+`morphedByMany`, `embedsOne` and `embedsMany`.
 
 Anything else throws a `LogicException` rather than returning a wrong value: `morphTo`, `hasManyThrough`, and
 hybrid relations where the related model is not stored in MongoDB.

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -15,6 +15,7 @@ use MongoDB\Builder\Type\SearchOperatorInterface;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Laravel\Connection;
+use MongoDB\Laravel\Helpers\QueriesRelationshipAggregates;
 use MongoDB\Laravel\Helpers\QueriesRelationships;
 use MongoDB\Laravel\Query\AggregationBuilder;
 use MongoDB\Model\BSONDocument;
@@ -38,6 +39,7 @@ use function value;
 class Builder extends EloquentBuilder
 {
     use QueriesRelationships;
+    use QueriesRelationshipAggregates;
 
     private const DUPLICATE_KEY_ERROR = 11000;
 

--- a/src/Helpers/QueriesRelationshipAggregates.php
+++ b/src/Helpers/QueriesRelationshipAggregates.php
@@ -71,9 +71,13 @@ trait QueriesRelationshipAggregates
 
             $relation = $this->getRelationWithoutConstraints($name);
             $this->assertAggregateRelationSupported($relation, $name);
+            $this->assertEmbeddedConstraintsSupported($relation, $name, $constraints);
 
+            // The key used to match the aggregated values with the parent documents must be read.
             $parentKey = $this->getAggregateParentKey($relation);
-            $this->prepareAggregateQuery($relation, $name, $parentKey, $constraints);
+            if ($parentKey !== null && $this->getQuery()->columns !== null) {
+                $this->addSelect($parentKey);
+            }
 
             $this->withAggregates[$alias] = [
                 'name' => $name,
@@ -110,22 +114,12 @@ trait QueriesRelationshipAggregates
         return [$name, $alias];
     }
 
-    private function prepareAggregateQuery(Relation $relation, string $name, ?string $parentKey, Closure $constraints): void
+    private function assertEmbeddedConstraintsSupported(Relation $relation, string $name, Closure $constraints): void
     {
-        if ($relation instanceof EmbedsOneOrMany) {
-            $this->assertEmbeddedConstraintsSupported($relation, $name, $constraints);
-
+        if (! $relation instanceof EmbedsOneOrMany) {
             return;
         }
 
-        // The key used to match the aggregated values with the parent documents must be read.
-        if ($parentKey !== null && $this->getQuery()->columns !== null) {
-            $this->addSelect($parentKey);
-        }
-    }
-
-    private function assertEmbeddedConstraintsSupported(EmbedsOneOrMany $relation, string $name, Closure $constraints): void
-    {
         $subQuery = $relation->getRelated()->newQuery();
         $constraints($subQuery);
 
@@ -159,13 +153,11 @@ trait QueriesRelationshipAggregates
 
         // Embedded documents are already part of the parent document, no query is needed.
         if ($relation instanceof EmbedsOneOrMany) {
-            $default = self::aggregateDefault($aggregate['function']);
             foreach ($models as $model) {
                 $model->setAttribute($alias, self::aggregateValues(
                     $model->{$aggregate['name']}()->getResults(),
                     $aggregate['function'],
                     $aggregate['column'],
-                    $default,
                 ));
             }
 
@@ -225,13 +217,12 @@ trait QueriesRelationshipAggregates
     {
         $relation->match($models, $relation->getEager(), $alias);
 
-        $default = self::aggregateDefault($aggregate['function']);
         foreach ($models as $model) {
             // match() leaves the relation unset on models without related documents.
             $related = $model->relationLoaded($alias) ? $model->getRelation($alias) : null;
             $model->unsetRelation($alias);
 
-            $model->setAttribute($alias, self::aggregateValues($related, $aggregate['function'], $aggregate['column'], $default));
+            $model->setAttribute($alias, self::aggregateValues($related, $aggregate['function'], $aggregate['column']));
         }
     }
 
@@ -244,7 +235,7 @@ trait QueriesRelationshipAggregates
         };
     }
 
-    private static function aggregateValues(mixed $related, string $function, string $column, mixed $default): mixed
+    private static function aggregateValues(mixed $related, string $function, string $column): mixed
     {
         $values = match (true) {
             $related instanceof Collection => $related,
@@ -253,7 +244,7 @@ trait QueriesRelationshipAggregates
         };
 
         if ($values->isEmpty()) {
-            return $default;
+            return self::aggregateDefault($function);
         }
 
         return match ($function) {

--- a/src/Helpers/QueriesRelationshipAggregates.php
+++ b/src/Helpers/QueriesRelationshipAggregates.php
@@ -67,40 +67,13 @@ trait QueriesRelationshipAggregates
         }
 
         foreach ($this->parseWithRelations(is_array($relations) ? $relations : [$relations]) as $name => $constraints) {
-            $segments = explode(' ', $name);
-            $alias = null;
-
-            if (count($segments) === 3 && strtolower($segments[1]) === 'as') {
-                [$name, $alias] = [$segments[0], $segments[2]];
-            }
-
-            // Same alias as Illuminate\Database\Eloquent\Concerns\QueriesRelationships::withAggregate
-            $alias ??= Str::snake(preg_replace(
-                '/[^[:alnum:][:space:]_]/u',
-                '',
-                sprintf('%s %s %s', $name, $function, strtolower($column)),
-            ));
+            [$name, $alias] = $this->resolveAggregateAlias($name, $function, $column);
 
             $relation = $this->getRelationWithoutConstraints($name);
-
             $this->assertAggregateRelationSupported($relation, $name);
 
             $parentKey = $this->getAggregateParentKey($relation);
-
-            if ($relation instanceof EmbedsOneOrMany) {
-                $subQuery = $relation->getRelated()->newQuery();
-                $constraints($subQuery);
-
-                if ($subQuery->getQuery()->wheres) {
-                    throw new LogicException(sprintf(
-                        'Constraints on the embedded relation "%s" are not supported. See https://jira.mongodb.org/browse/PHPORM-292',
-                        $name,
-                    ));
-                }
-            } elseif ($parentKey !== null && $this->getQuery()->columns !== null) {
-                // The key used to match the aggregated values with the parent documents must be read.
-                $this->addSelect($parentKey);
-            }
+            $this->prepareAggregateQuery($relation, $name, $parentKey, $constraints);
 
             $this->withAggregates[$alias] = [
                 'name' => $name,
@@ -112,6 +85,56 @@ trait QueriesRelationshipAggregates
         }
 
         return $this;
+    }
+
+    /**
+     * Resolve the relation name and the attribute alias, using the same alias as
+     * Illuminate\Database\Eloquent\Concerns\QueriesRelationships::withAggregate.
+     *
+     * @return array{0: string, 1: string} the relation name and the alias
+     */
+    private function resolveAggregateAlias(string $name, string $function, string $column): array
+    {
+        $segments = explode(' ', $name);
+
+        if (count($segments) === 3 && strtolower($segments[1]) === 'as') {
+            return [$segments[0], $segments[2]];
+        }
+
+        $alias = Str::snake(preg_replace(
+            '/[^[:alnum:][:space:]_]/u',
+            '',
+            sprintf('%s %s %s', $name, $function, strtolower($column)),
+        ));
+
+        return [$name, $alias];
+    }
+
+    private function prepareAggregateQuery(Relation $relation, string $name, ?string $parentKey, Closure $constraints): void
+    {
+        if ($relation instanceof EmbedsOneOrMany) {
+            $this->assertEmbeddedConstraintsSupported($relation, $name, $constraints);
+
+            return;
+        }
+
+        // The key used to match the aggregated values with the parent documents must be read.
+        if ($parentKey !== null && $this->getQuery()->columns !== null) {
+            $this->addSelect($parentKey);
+        }
+    }
+
+    private function assertEmbeddedConstraintsSupported(EmbedsOneOrMany $relation, string $name, Closure $constraints): void
+    {
+        $subQuery = $relation->getRelated()->newQuery();
+        $constraints($subQuery);
+
+        if ($subQuery->getQuery()->wheres) {
+            throw new LogicException(sprintf(
+                'Constraints on the embedded relation "%s" are not supported.',
+                $name,
+            ));
+        }
     }
 
     /** @inheritdoc */

--- a/src/Helpers/QueriesRelationshipAggregates.php
+++ b/src/Helpers/QueriesRelationshipAggregates.php
@@ -18,17 +18,21 @@ use LogicException;
 use MongoDB\BSON\Binary;
 use MongoDB\Laravel\Eloquent\Model as DocumentModel;
 use MongoDB\Laravel\Relations\EmbedsOneOrMany;
+use Stringable;
 
 use function bin2hex;
 use function class_basename;
 use function count;
 use function explode;
+use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_scalar;
 use function is_string;
 use function preg_replace;
 use function sprintf;
+use function str_starts_with;
 use function strtolower;
 
 /**
@@ -64,6 +68,13 @@ trait QueriesRelationshipAggregates
 
         if (! is_string($column)) {
             throw new InvalidArgumentException('The aggregate column name must be a string.');
+        }
+
+        if (str_starts_with($column, '$')) {
+            throw new InvalidArgumentException(sprintf(
+                'The aggregate column name "%s" must not start with "$".',
+                $column,
+            ));
         }
 
         foreach ($this->parseWithRelations(is_array($relations) ? $relations : [$relations]) as $name => $constraints) {
@@ -260,7 +271,18 @@ trait QueriesRelationshipAggregates
     /** Document keys are compared as strings, as ObjectId instances are not identical. */
     private static function aggregateKey(mixed $value): string
     {
-        return $value instanceof Binary ? bin2hex($value->getData()) : (string) $value;
+        if ($value instanceof Binary) {
+            return bin2hex($value->getData());
+        }
+
+        if (is_scalar($value) || $value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'The relation key of type "%s" cannot be used to match aggregated values.',
+            get_debug_type($value),
+        ));
     }
 
     private function assertAggregateRelationSupported(Relation $relation, string $name): void

--- a/src/Helpers/QueriesRelationshipAggregates.php
+++ b/src/Helpers/QueriesRelationshipAggregates.php
@@ -63,7 +63,7 @@ trait QueriesRelationshipAggregates
         }
 
         if (! is_string($column)) {
-            throw new InvalidArgumentException('Expressions are not supported as aggregate column by MongoDB.');
+            throw new InvalidArgumentException('The aggregate column name must be a string.');
         }
 
         foreach ($this->parseWithRelations(is_array($relations) ? $relations : [$relations]) as $name => $constraints) {
@@ -131,22 +131,16 @@ trait QueriesRelationshipAggregates
      */
     private function hydrateAggregate(array $models, string $alias, array $aggregate): void
     {
-        $function = $aggregate['function'];
-        $default = match ($function) {
-            'count' => 0,
-            'exists' => false,
-            default => null,
-        };
-
         // The relation is resolved for each execution to start from a query without constraints.
         $relation = $this->getRelationWithoutConstraints($aggregate['name']);
 
-        // Embedded documents are already part of the parent document.
+        // Embedded documents are already part of the parent document, no query is needed.
         if ($relation instanceof EmbedsOneOrMany) {
+            $default = self::aggregateDefault($aggregate['function']);
             foreach ($models as $model) {
                 $model->setAttribute($alias, self::aggregateValues(
                     $model->{$aggregate['name']}()->getResults(),
-                    $function,
+                    $aggregate['function'],
                     $aggregate['column'],
                     $default,
                 ));
@@ -160,25 +154,9 @@ trait QueriesRelationshipAggregates
         // the constraints are applied to the query of the related model.
         $aggregate['constraints']($relation->getQuery());
 
+        // HasOneOrMany relations are aggregated by the server, grouped by foreign key.
         if ($relation instanceof HasOneOrMany) {
-            // The values are aggregated by the server, grouped by foreign key.
-            $foreignKey = $this->getHasCompareKey($relation);
-            $results = $relation->getQuery()->toBase()
-                ->groupBy($foreignKey)
-                ->aggregate($function === 'exists' ? 'count' : $function, [$aggregate['column']]);
-
-            $values = [];
-            foreach ($results as $result) {
-                $values[self::aggregateKey($result->{$foreignKey})] = $function === 'exists'
-                    ? $result->aggregate > 0
-                    : $result->aggregate;
-            }
-
-            foreach ($models as $model) {
-                $key = self::aggregateKey($model->getAttribute($aggregate['parentKey']));
-
-                $model->setAttribute($alias, $values[$key] ?? $default);
-            }
+            $this->hydrateGroupedAggregate($models, $alias, $aggregate, $relation);
 
             return;
         }
@@ -186,15 +164,61 @@ trait QueriesRelationshipAggregates
         // The related documents cannot be grouped by the server: a BelongsTo relation has a single
         // related document per parent, and the keys of many-to-many relations are stored in an array
         // field. The eager loading logic is reused to match the related documents to their parent.
+        $this->hydrateMatchedAggregate($models, $alias, $aggregate, $relation);
+    }
+
+    /**
+     * @param EloquentModel[]                                                                                 $models
+     * @param array{name: string, function: string, column: string, parentKey: ?string, constraints: Closure} $aggregate
+     */
+    private function hydrateGroupedAggregate(array $models, string $alias, array $aggregate, HasOneOrMany $relation): void
+    {
+        $function = $aggregate['function'];
+        $foreignKey = $this->getHasCompareKey($relation);
+        $results = $relation->getQuery()->toBase()
+            ->groupBy($foreignKey)
+            ->aggregate($function === 'exists' ? 'count' : $function, [$aggregate['column']]);
+
+        $values = [];
+        foreach ($results as $result) {
+            $values[self::aggregateKey($result->{$foreignKey})] = $function === 'exists'
+                ? $result->aggregate > 0
+                : $result->aggregate;
+        }
+
+        $default = self::aggregateDefault($function);
+        foreach ($models as $model) {
+            $key = self::aggregateKey($model->getAttribute($aggregate['parentKey']));
+
+            $model->setAttribute($alias, $values[$key] ?? $default);
+        }
+    }
+
+    /**
+     * @param EloquentModel[]                                                                                 $models
+     * @param array{name: string, function: string, column: string, parentKey: ?string, constraints: Closure} $aggregate
+     */
+    private function hydrateMatchedAggregate(array $models, string $alias, array $aggregate, Relation $relation): void
+    {
         $relation->match($models, $relation->getEager(), $alias);
 
+        $default = self::aggregateDefault($aggregate['function']);
         foreach ($models as $model) {
             // match() leaves the relation unset on models without related documents.
             $related = $model->relationLoaded($alias) ? $model->getRelation($alias) : null;
             $model->unsetRelation($alias);
 
-            $model->setAttribute($alias, self::aggregateValues($related, $function, $aggregate['column'], $default));
+            $model->setAttribute($alias, self::aggregateValues($related, $aggregate['function'], $aggregate['column'], $default));
         }
+    }
+
+    private static function aggregateDefault(string $function): mixed
+    {
+        return match ($function) {
+            'count' => 0,
+            'exists' => false,
+            default => null,
+        };
     }
 
     private static function aggregateValues(mixed $related, string $function, string $column, mixed $default): mixed

--- a/src/Helpers/QueriesRelationshipAggregates.php
+++ b/src/Helpers/QueriesRelationshipAggregates.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Helpers;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use LogicException;
+use MongoDB\BSON\Binary;
+use MongoDB\Laravel\Eloquent\Model as DocumentModel;
+use MongoDB\Laravel\Relations\EmbedsOneOrMany;
+
+use function bin2hex;
+use function class_basename;
+use function count;
+use function explode;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function preg_replace;
+use function sprintf;
+use function strtolower;
+
+/**
+ * Support for withCount, withExists, withSum, withAvg, withMin and withMax on document models.
+ *
+ * MongoDB has no correlated subquery, so the values cannot be selected with the parent documents
+ * as Eloquent does. They are computed with one additional query per aggregate, after the parent
+ * documents are read.
+ *
+ * @internal
+ */
+trait QueriesRelationshipAggregates
+{
+    private const AGGREGATE_FUNCTIONS = ['count', 'exists', 'sum', 'avg', 'min', 'max'];
+
+    /** @var array<string, array{name: string, function: string, column: string, parentKey: ?string, constraints: Closure}> */
+    private array $withAggregates = [];
+
+    /** @inheritdoc */
+    public function withAggregate($relations, $column, $function = null)
+    {
+        if (empty($relations)) {
+            return $this;
+        }
+
+        if (! in_array($function, self::AGGREGATE_FUNCTIONS, true)) {
+            throw new InvalidArgumentException(sprintf(
+                'Aggregate function "%s" is not supported by MongoDB. Supported functions are: %s.',
+                $function ?? 'null',
+                implode(', ', self::AGGREGATE_FUNCTIONS),
+            ));
+        }
+
+        if (! is_string($column)) {
+            throw new InvalidArgumentException('Expressions are not supported as aggregate column by MongoDB.');
+        }
+
+        foreach ($this->parseWithRelations(is_array($relations) ? $relations : [$relations]) as $name => $constraints) {
+            $segments = explode(' ', $name);
+            $alias = null;
+
+            if (count($segments) === 3 && strtolower($segments[1]) === 'as') {
+                [$name, $alias] = [$segments[0], $segments[2]];
+            }
+
+            // Same alias as Illuminate\Database\Eloquent\Concerns\QueriesRelationships::withAggregate
+            $alias ??= Str::snake(preg_replace(
+                '/[^[:alnum:][:space:]_]/u',
+                '',
+                sprintf('%s %s %s', $name, $function, strtolower($column)),
+            ));
+
+            $relation = $this->getRelationWithoutConstraints($name);
+
+            $this->assertAggregateRelationSupported($relation, $name);
+
+            $parentKey = $this->getAggregateParentKey($relation);
+
+            if ($relation instanceof EmbedsOneOrMany) {
+                $subQuery = $relation->getRelated()->newQuery();
+                $constraints($subQuery);
+
+                if ($subQuery->getQuery()->wheres) {
+                    throw new LogicException(sprintf(
+                        'Constraints on the embedded relation "%s" are not supported. See https://jira.mongodb.org/browse/PHPORM-292',
+                        $name,
+                    ));
+                }
+            } elseif ($parentKey !== null && $this->getQuery()->columns !== null) {
+                // The key used to match the aggregated values with the parent documents must be read.
+                $this->addSelect($parentKey);
+            }
+
+            $this->withAggregates[$alias] = [
+                'name' => $name,
+                'function' => $function,
+                'column' => $column,
+                'parentKey' => $parentKey,
+                'constraints' => $constraints,
+            ];
+        }
+
+        return $this;
+    }
+
+    /** @inheritdoc */
+    public function eagerLoadRelations(array $models)
+    {
+        foreach ($this->withAggregates as $alias => $aggregate) {
+            $this->assertAggregateNotUsedInQuery($alias);
+            $this->hydrateAggregate($models, $alias, $aggregate);
+        }
+
+        return parent::eagerLoadRelations($models);
+    }
+
+    /**
+     * @param EloquentModel[]                                                                                 $models
+     * @param array{name: string, function: string, column: string, parentKey: ?string, constraints: Closure} $aggregate
+     */
+    private function hydrateAggregate(array $models, string $alias, array $aggregate): void
+    {
+        $function = $aggregate['function'];
+        $default = match ($function) {
+            'count' => 0,
+            'exists' => false,
+            default => null,
+        };
+
+        // The relation is resolved for each execution to start from a query without constraints.
+        $relation = $this->getRelationWithoutConstraints($aggregate['name']);
+
+        // Embedded documents are already part of the parent document.
+        if ($relation instanceof EmbedsOneOrMany) {
+            foreach ($models as $model) {
+                $model->setAttribute($alias, self::aggregateValues(
+                    $model->{$aggregate['name']}()->getResults(),
+                    $function,
+                    $aggregate['column'],
+                    $default,
+                ));
+            }
+
+            return;
+        }
+
+        $relation->addEagerConstraints($models);
+        // Same as Illuminate\Database\Eloquent\Concerns\QueriesRelationships::withAggregate,
+        // the constraints are applied to the query of the related model.
+        $aggregate['constraints']($relation->getQuery());
+
+        if ($relation instanceof HasOneOrMany) {
+            // The values are aggregated by the server, grouped by foreign key.
+            $foreignKey = $this->getHasCompareKey($relation);
+            $results = $relation->getQuery()->toBase()
+                ->groupBy($foreignKey)
+                ->aggregate($function === 'exists' ? 'count' : $function, [$aggregate['column']]);
+
+            $values = [];
+            foreach ($results as $result) {
+                $values[self::aggregateKey($result->{$foreignKey})] = $function === 'exists'
+                    ? $result->aggregate > 0
+                    : $result->aggregate;
+            }
+
+            foreach ($models as $model) {
+                $key = self::aggregateKey($model->getAttribute($aggregate['parentKey']));
+
+                $model->setAttribute($alias, $values[$key] ?? $default);
+            }
+
+            return;
+        }
+
+        // The related documents cannot be grouped by the server: a BelongsTo relation has a single
+        // related document per parent, and the keys of many-to-many relations are stored in an array
+        // field. The eager loading logic is reused to match the related documents to their parent.
+        $relation->match($models, $relation->getEager(), $alias);
+
+        foreach ($models as $model) {
+            // match() leaves the relation unset on models without related documents.
+            $related = $model->relationLoaded($alias) ? $model->getRelation($alias) : null;
+            $model->unsetRelation($alias);
+
+            $model->setAttribute($alias, self::aggregateValues($related, $function, $aggregate['column'], $default));
+        }
+    }
+
+    private static function aggregateValues(mixed $related, string $function, string $column, mixed $default): mixed
+    {
+        $values = match (true) {
+            $related instanceof Collection => $related,
+            $related === null => new Collection(),
+            default => new Collection([$related]),
+        };
+
+        if ($values->isEmpty()) {
+            return $default;
+        }
+
+        return match ($function) {
+            'count' => $values->count(),
+            'exists' => true,
+            'sum' => $values->sum($column),
+            'avg' => $values->avg($column),
+            'min' => $values->min($column),
+            'max' => $values->max($column),
+        };
+    }
+
+    /** Document keys are compared as strings, as ObjectId instances are not identical. */
+    private static function aggregateKey(mixed $value): string
+    {
+        return $value instanceof Binary ? bin2hex($value->getData()) : (string) $value;
+    }
+
+    private function assertAggregateRelationSupported(Relation $relation, string $name): void
+    {
+        if ($relation instanceof EmbedsOneOrMany) {
+            return;
+        }
+
+        if (! DocumentModel::isDocumentModel($relation->getRelated()) || $this->isAcrossConnections($relation)) {
+            throw new LogicException(sprintf(
+                'Aggregating the hybrid relation "%s" is not supported. The related model must be stored in MongoDB.',
+                $name,
+            ));
+        }
+
+        if (
+            $relation instanceof HasOneOrMany
+            || $relation instanceof BelongsToMany
+            || ($relation instanceof BelongsTo && ! $relation instanceof MorphTo)
+        ) {
+            return;
+        }
+
+        throw new LogicException(sprintf(
+            '%s is not supported for relation aggregates.',
+            class_basename($relation),
+        ));
+    }
+
+    private function getAggregateParentKey(Relation $relation): ?string
+    {
+        return match (true) {
+            $relation instanceof HasOneOrMany => $relation->getLocalKeyName(),
+            $relation instanceof BelongsTo => $relation->getForeignKeyName(),
+            $relation instanceof BelongsToMany => $relation->getParentKeyName(),
+            default => null,
+        };
+    }
+
+    /** The aggregated value does not exist in the documents, the server cannot use it. */
+    private function assertAggregateNotUsedInQuery(string $alias): void
+    {
+        if (isset($this->getQuery()->orders[$alias])) {
+            throw new LogicException(sprintf(
+                'Ordering by the aggregated field "%s" is not supported, as it is computed after the documents are read. Sort the results with the collection method "sortBy" instead.',
+                $alias,
+            ));
+        }
+    }
+}

--- a/src/Helpers/QueriesRelationshipAggregates.php
+++ b/src/Helpers/QueriesRelationshipAggregates.php
@@ -133,8 +133,9 @@ trait QueriesRelationshipAggregates
 
         $subQuery = $relation->getRelated()->newQuery();
         $constraints($subQuery);
+        $query = $subQuery->getQuery();
 
-        if ($subQuery->getQuery()->wheres) {
+        if ($query->wheres || $query->limit !== null || $query->offset !== null || $query->distinct) {
             throw new LogicException(sprintf(
                 'Constraints on the embedded relation "%s" are not supported.',
                 $name,

--- a/tests/Eloquent/WithAggregateTest.php
+++ b/tests/Eloquent/WithAggregateTest.php
@@ -1,0 +1,349 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use LogicException;
+use MongoDB\Laravel\Tests\Models\Book;
+use MongoDB\Laravel\Tests\Models\Client;
+use MongoDB\Laravel\Tests\Models\Item;
+use MongoDB\Laravel\Tests\Models\Label;
+use MongoDB\Laravel\Tests\Models\Photo;
+use MongoDB\Laravel\Tests\Models\Role;
+use MongoDB\Laravel\Tests\Models\Soft;
+use MongoDB\Laravel\Tests\Models\User;
+use MongoDB\Laravel\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function assert;
+
+class WithAggregateTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        DB::connection('mongodb')->disableQueryLog();
+
+        User::truncate();
+        Book::truncate();
+        Item::truncate();
+        Role::truncate();
+        Client::truncate();
+        Label::truncate();
+        Photo::truncate();
+        Soft::truncate();
+
+        parent::tearDown();
+    }
+
+    public function testWithCountHasMany(): void
+    {
+        $author = User::create(['name' => 'Alice']);
+        $author->books()->create(['title' => 'A']);
+        $author->books()->create(['title' => 'B']);
+        User::create(['name' => 'Bob']);
+
+        $users = User::withCount('books')->orderBy('name')->get();
+
+        self::assertSame(2, $users[0]->books_count);
+        self::assertSame(0, $users[1]->books_count);
+    }
+
+    public function testWithExistsHasMany(): void
+    {
+        $author = User::create(['name' => 'Alice']);
+        $author->books()->create(['title' => 'A']);
+        User::create(['name' => 'Bob']);
+
+        $users = User::withExists('books')->orderBy('name')->get();
+
+        self::assertTrue($users[0]->books_exists);
+        self::assertFalse($users[1]->books_exists);
+    }
+
+    #[DataProvider('provideAggregateFunctions')]
+    public function testWithAggregateHasMany(string $method, string $alias, mixed $expected, mixed $default): void
+    {
+        $user = User::create(['name' => 'Alice']);
+        $user->items()->create(['name' => 'knife', 'amount' => 4]);
+        $user->items()->create(['name' => 'fork', 'amount' => 6]);
+        User::create(['name' => 'Bob']);
+
+        $users = User::$method('items', 'amount')->orderBy('name')->get();
+
+        self::assertSame($expected, $users[0]->$alias);
+        self::assertSame($default, $users[1]->$alias);
+    }
+
+    public static function provideAggregateFunctions(): iterable
+    {
+        yield 'sum' => ['withSum', 'items_sum_amount', 10, null];
+        yield 'avg' => ['withAvg', 'items_avg_amount', 5.0, null];
+        yield 'min' => ['withMin', 'items_min_amount', 4, null];
+        yield 'max' => ['withMax', 'items_max_amount', 6, null];
+    }
+
+    public function testWithAggregateUsesASingleQueryPerAggregate(): void
+    {
+        $user = User::create(['name' => 'Alice']);
+        $user->books()->create(['title' => 'A']);
+        $user->items()->create(['name' => 'knife', 'amount' => 4]);
+        $user->role()->create(['type' => 'admin']);
+        User::create(['name' => 'Bob']);
+
+        $connection = DB::connection('mongodb');
+        $connection->enableQueryLog();
+
+        $users = User::withCount('books')
+            ->withMax('items', 'amount')
+            ->withExists('role')
+            ->orderBy('name')
+            ->get();
+
+        self::assertCount(4, $connection->getQueryLog());
+
+        self::assertSame(1, $users[0]->books_count);
+        self::assertSame(4, $users[0]->items_max_amount);
+        self::assertTrue($users[0]->role_exists);
+
+        self::assertSame(0, $users[1]->books_count);
+        self::assertNull($users[1]->items_max_amount);
+        self::assertFalse($users[1]->role_exists);
+    }
+
+    public function testWithCountAlias(): void
+    {
+        $author = User::create(['name' => 'Alice']);
+        $author->books()->create(['title' => 'A']);
+
+        $user = User::withCount('books as book_total')->withMax('items as top_amount', 'amount')->first();
+
+        self::assertSame(1, $user->book_total);
+        self::assertNull($user->top_amount);
+    }
+
+    public function testWithCountConstraints(): void
+    {
+        $user = User::create(['name' => 'Alice']);
+        $user->items()->create(['name' => 'knife', 'amount' => 4]);
+        $user->items()->create(['name' => 'fork', 'amount' => 6]);
+        $user->items()->create(['name' => 'spoon', 'amount' => 8]);
+
+        $filter = static fn (Builder $query) => $query->where('amount', '<=', 6);
+
+        self::assertSame(2, User::withCount(['items' => $filter])->first()->items_count);
+        self::assertSame(6, User::withMax(['items' => $filter], 'amount')->first()->items_max_amount);
+        self::assertSame(2, User::withCount(['items as cheap' => $filter])->first()->cheap);
+    }
+
+    public function testWithCountAppliesGlobalScopesOfRelated(): void
+    {
+        $user = User::create(['name' => 'Alice']);
+        $user->softs()->create(['title' => 'A']);
+        $user->softs()->create(['title' => 'B'])->delete();
+
+        $user = User::withCount('softs')->withCount('softsWithTrashed')->first();
+
+        self::assertSame(1, $user->softs_count);
+        self::assertSame(2, $user->softs_with_trashed_count);
+    }
+
+    public function testWithCountHasOne(): void
+    {
+        User::create(['name' => 'Alice'])->role()->create(['type' => 'admin']);
+        User::create(['name' => 'Bob']);
+
+        $users = User::withCount('role')->orderBy('name')->get();
+
+        self::assertSame(1, $users[0]->role_count);
+        self::assertSame(0, $users[1]->role_count);
+    }
+
+    public function testWithCountMorphMany(): void
+    {
+        $user = User::create(['name' => 'Alice']);
+        $user->photos()->create(['url' => 'user.jpg']);
+        Client::create(['name' => 'Acme'])->photo()->create(['url' => 'client.jpg']);
+
+        $user = User::withCount('photos')->first();
+
+        self::assertSame(1, $user->photos_count);
+    }
+
+    public function testWithAggregateBelongsTo(): void
+    {
+        $author = User::create(['name' => 'Alice', 'age' => 37]);
+        $author->books()->create(['title' => 'A']);
+        Book::create(['title' => 'Anonymous']);
+
+        $books = Book::withCount('author')->withExists('author')->withMax('author', 'age')->orderBy('title')->get();
+
+        self::assertSame(1, $books[0]->author_count);
+        self::assertTrue($books[0]->author_exists);
+        self::assertSame(37, $books[0]->author_max_age);
+
+        self::assertSame(0, $books[1]->author_count);
+        self::assertFalse($books[1]->author_exists);
+        self::assertNull($books[1]->author_max_age);
+    }
+
+    public function testWithCountBelongsToMany(): void
+    {
+        $user = User::create(['name' => 'Alice']);
+        $user->clients()->create(['name' => 'Acme']);
+        $user->clients()->create(['name' => 'Globex']);
+        User::create(['name' => 'Bob']);
+
+        $users = User::withCount('clients')->withExists('clients')->orderBy('name')->get();
+
+        self::assertSame(2, $users[0]->clients_count);
+        self::assertTrue($users[0]->clients_exists);
+        self::assertSame(0, $users[1]->clients_count);
+        self::assertFalse($users[1]->clients_exists);
+    }
+
+    public function testWithCountMorphToMany(): void
+    {
+        $user = User::create(['name' => 'Alice']);
+        $user->labels()->create(['name' => 'red']);
+        $user->labels()->create(['name' => 'blue']);
+        Client::create(['name' => 'Acme'])->labels()->create(['name' => 'green']);
+
+        $user = User::withCount('labels')->first();
+        self::assertSame(2, $user->labels_count);
+
+        // Inverse relation, the parent keys are stored in the pivot column of the label
+        $label = Label::where('name', 'green')->withCount('clients')->first();
+        self::assertSame(1, $label->clients_count);
+    }
+
+    public function testWithAggregateEmbedsMany(): void
+    {
+        $user = User::create(['name' => 'Alice']);
+        $user->addresses()->create(['city' => 'Paris', 'zip' => 75001]);
+        $user->addresses()->create(['city' => 'Lyon', 'zip' => 69001]);
+        User::create(['name' => 'Bob']);
+
+        $connection = DB::connection('mongodb');
+        $connection->enableQueryLog();
+
+        $users = User::withCount('addresses')
+            ->withExists('addresses')
+            ->withMax('addresses', 'zip')
+            ->orderBy('name')
+            ->get();
+
+        // Embedded documents are read with the parent document
+        self::assertCount(1, $connection->getQueryLog());
+
+        self::assertSame(2, $users[0]->addresses_count);
+        self::assertTrue($users[0]->addresses_exists);
+        self::assertSame(75001, $users[0]->addresses_max_zip);
+
+        self::assertSame(0, $users[1]->addresses_count);
+        self::assertFalse($users[1]->addresses_exists);
+        self::assertNull($users[1]->addresses_max_zip);
+    }
+
+    public function testWithAggregateEmbedsOne(): void
+    {
+        $user = User::create(['name' => 'Alice']);
+        $user->father()->save(new User(['name' => 'Mark Doe', 'age' => 70]));
+        User::create(['name' => 'Bob']);
+
+        $users = User::withCount('father')->withExists('father')->orderBy('name')->get();
+
+        self::assertSame(1, $users[0]->father_count);
+        self::assertTrue($users[0]->father_exists);
+        self::assertSame(0, $users[1]->father_count);
+        self::assertFalse($users[1]->father_exists);
+    }
+
+    public function testAggregateIsAddedToArray(): void
+    {
+        User::create(['name' => 'Alice'])->books()->create(['title' => 'A']);
+
+        $user = User::withCount('books')->first();
+
+        self::assertSame(1, $user->toArray()['books_count']);
+    }
+
+    public function testLoadCountAndLoadExists(): void
+    {
+        $user = User::create(['name' => 'Alice']);
+        $user->books()->create(['title' => 'A']);
+
+        $user = User::first();
+        $user->loadCount('books');
+        $user->loadExists('role');
+
+        self::assertSame(1, $user->books_count);
+        self::assertFalse($user->role_exists);
+
+        $users = User::all();
+        $users->loadCount('books');
+
+        self::assertSame(1, $users[0]->books_count);
+    }
+
+    public function testWithCountWithSelectAndPaginate(): void
+    {
+        $author = User::create(['name' => 'Alice']);
+        $author->books()->create(['title' => 'A']);
+        User::create(['name' => 'Bob']);
+
+        $users = User::withCount('books')->select('name')->orderBy('name')->paginate(1);
+
+        self::assertSame(2, $users->total());
+        self::assertSame(1, $users[0]->books_count);
+        self::assertSame('Alice', $users[0]->name);
+    }
+
+    public function testOrderByAggregateIsNotSupported(): void
+    {
+        User::create(['name' => 'Alice']);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Ordering by the aggregated field "books_count" is not supported');
+
+        User::withCount('books')->orderBy('books_count')->get();
+    }
+
+    public function testHybridRelationIsNotSupported(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Aggregating the hybrid relation "sqlBooks" is not supported');
+
+        User::withCount('sqlBooks')->get();
+    }
+
+    public function testMorphToIsNotSupported(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('MorphTo is not supported for relation aggregates');
+
+        Photo::withCount('hasImage')->get();
+    }
+
+    public function testConstraintsOnEmbeddedRelationAreNotSupported(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Constraints on the embedded relation "addresses" are not supported');
+
+        User::withCount(['addresses' => static fn (Builder $query) => $query->where('city', 'Paris')])->get();
+    }
+
+    public function testUnsupportedFunction(): void
+    {
+        $builder = User::query();
+        assert($builder instanceof \MongoDB\Laravel\Eloquent\Builder);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Aggregate function "stdDevPop" is not supported by MongoDB');
+
+        $builder->withAggregate('books', 'title', 'stdDevPop');
+    }
+}

--- a/tests/Eloquent/WithAggregateTest.php
+++ b/tests/Eloquent/WithAggregateTest.php
@@ -345,6 +345,14 @@ class WithAggregateTest extends TestCase
         User::withCount(['addresses' => static fn (Builder $query) => $query->where('city', 'Paris')])->get();
     }
 
+    public function testLimitOnEmbeddedRelationIsNotSupported(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Constraints on the embedded relation "addresses" are not supported');
+
+        User::withCount(['addresses' => static fn (Builder $query) => $query->limit(1)])->get();
+    }
+
     public function testUnsupportedFunction(): void
     {
         $builder = User::query();

--- a/tests/Eloquent/WithAggregateTest.php
+++ b/tests/Eloquent/WithAggregateTest.php
@@ -355,4 +355,24 @@ class WithAggregateTest extends TestCase
 
         $builder->withAggregate('books', 'title', 'stdDevPop');
     }
+
+    public function testColumnStartingWithDollarIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The aggregate column name "$ROOT" must not start with "$"');
+
+        User::withSum('books', '$ROOT');
+    }
+
+    public function testNonScalarRelationKeyIsRejected(): void
+    {
+        $author = User::create(['name' => 'Alice']);
+        $author->books()->create(['title' => 'A']);
+        User::insert([['name' => 'Bob', '_id' => ['nested' => 'key']]]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The relation key of type "array" cannot be used to match aggregated values.');
+
+        User::withCount('books')->get();
+    }
 }

--- a/tests/Eloquent/WithAggregateTest.php
+++ b/tests/Eloquent/WithAggregateTest.php
@@ -233,6 +233,9 @@ class WithAggregateTest extends TestCase
         $users = User::withCount('addresses')
             ->withExists('addresses')
             ->withMax('addresses', 'zip')
+            ->withMin('addresses', 'zip')
+            ->withSum('addresses', 'zip')
+            ->withAvg('addresses', 'zip')
             ->orderBy('name')
             ->get();
 
@@ -242,10 +245,16 @@ class WithAggregateTest extends TestCase
         self::assertSame(2, $users[0]->addresses_count);
         self::assertTrue($users[0]->addresses_exists);
         self::assertSame(75001, $users[0]->addresses_max_zip);
+        self::assertSame(69001, $users[0]->addresses_min_zip);
+        self::assertSame(144002, $users[0]->addresses_sum_zip);
+        self::assertSame(72001, $users[0]->addresses_avg_zip);
 
         self::assertSame(0, $users[1]->addresses_count);
         self::assertFalse($users[1]->addresses_exists);
         self::assertNull($users[1]->addresses_max_zip);
+        self::assertNull($users[1]->addresses_min_zip);
+        self::assertNull($users[1]->addresses_sum_zip);
+        self::assertNull($users[1]->addresses_avg_zip);
     }
 
     public function testWithAggregateEmbedsOne(): void

--- a/tests/HybridRelationsTest.php
+++ b/tests/HybridRelationsTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Tests;
 
+use BadMethodCallException;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Facades\DB;
+use LogicException;
 use MongoDB\Laravel\Tests\Models\Book;
 use MongoDB\Laravel\Tests\Models\Experience;
 use MongoDB\Laravel\Tests\Models\Label;
@@ -283,6 +285,23 @@ class HybridRelationsTest extends TestCase
         SqlUser::whereHas('skills', function ($query) {
             return $query->where('name', 'LIKE', 'MongoDB');
         });
+    }
+
+    public function testWithCountOnHybridRelationFails()
+    {
+        // MongoModel -> HasMany -> SqlModel
+        try {
+            User::withCount('sqlBooks')->get();
+            self::fail('Expected a LogicException');
+        } catch (LogicException $e) {
+            self::assertStringContainsString('Aggregating the hybrid relation "sqlBooks" is not supported', $e->getMessage());
+        }
+
+        // SqlModel -> HasMany -> MongoModel
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('This method is not supported by MongoDB. Try "toMql()" instead.');
+
+        SqlUser::withCount('books')->get();
     }
 
     public function testHybridMorphToManySqlModelToMongoModel()

--- a/tests/skills/laravel-mongodb/evals/evals.json
+++ b/tests/skills/laravel-mongodb/evals/evals.json
@@ -27,13 +27,13 @@
     },
     {
       "id": 3,
-      "prompt": "How do I count the number of comments per post in Laravel with MongoDB?",
-      "expected_output": "Use a raw aggregation pipeline with $lookup and $size executed via Post::raw(), and avoid Eloquent's withCount().",
+      "prompt": "How do I count the number of comments per post in Laravel with MongoDB, and then list the posts from the most commented to the least commented?",
+      "expected_output": "Use Post::withCount('comments') to read the counts, but explain that ordering by the comments_count alias throws because the value is computed after the documents are read, so the sorted listing needs a raw $lookup + $size + $sort aggregation pipeline (or a PHP-side sortByDesc on the collection).",
       "expectations": [
-        "Does NOT use `Post::withCount('comments')` or `withCount(...)` on a MongoDB model",
-        "Uses a `$lookup` stage and a `$size` operator in an aggregation pipeline",
-        "Calls the aggregation via `Post::raw(...)` or `$collection->aggregate(...)`",
-        "Explicitly states that `withCount` is not supported with the Laravel MongoDB package"
+        "States that `Post::withCount('comments')` is supported and exposes a `comments_count` attribute",
+        "States that `orderBy('comments_count')` is NOT supported, because the aggregate is computed after the documents are read",
+        "Proposes a `$lookup` stage with a `$size` operator and a `$sort` stage to order by the count on the server",
+        "Calls the aggregation via `Post::raw(...)` or `$collection->aggregate(...)`"
       ]
     },
     {


### PR DESCRIPTION
Adds support for `withCount()`, `withExists()`, `withSum()`, `withAvg()`, `withMin()` and `withMax()` on document models. `loadCount()`, `loadExists()` and `loadAggregate()` work as well, since Laravel funnels them through the same `withAggregate()` method.

Before this change, any of them failed with `BadMethodCallException: This method is not supported by MongoDB. Try "toMql()" instead.`, because `Illuminate\Database\Eloquent\Concerns\QueriesRelationships::withAggregate()` builds a correlated subselect and calls `toSql()`.

Resolves PHPLARA-225, PHPLARA-93 and PHPLARA-237. Reported as #3003, #2470, #2435, #1801 and #1339.

## How it works

MongoDB has no correlated subquery, so the values cannot be selected with the parent documents as Eloquent does. The new `MongoDB\Laravel\Helpers\QueriesRelationshipAggregates` trait records the requested aggregates in `withAggregate()`, then computes them in `eagerLoadRelations()`, after the parent documents are read, and sets them as attributes.

The cost is one additional query per aggregate, whatever the number of parent documents:

- `HasOneOrMany` and its morph variants are aggregated by the server with a `$group` on the foreign key.
- `BelongsTo`, `BelongsToMany` and `MorphToMany` cannot be grouped server side (a single related document per parent, or parent keys stored in an array field), so the eager loading `match()` logic is reused and the values are folded in PHP.
- `EmbedsOne` and `EmbedsMany` need no query at all, they are computed from the parent document.

`exists` is computed as a grouped count mapped to `> 0` and stored as a real boolean, so no `bool` cast is added on the model.

Aliases follow Illuminate exactly, so `withCount('books')` gives `books_count`, `withMax('items', 'amount')` gives `items_max_amount` and `withCount('books as total')` gives `total`. Defaults with no related document are `0` for `count`, `false` for `exists` and `null` for the others.

## Limitations

Cases that cannot be supported throw a `LogicException` rather than returning a wrong value:

- `orderBy()` on an aggregate alias: the value does not exist server side, so a `$sort` on it would silently return unsorted results. A `$lookup` pipeline is required to sort on an aggregate.
- `MorphTo` and other relation types outside the set supported by `has()`.
- Hybrid relations, where the related model is not stored in MongoDB.
- Constraint closures on embedded relations (PHPORM-292).

`cursor()` and `lazy()` do not call `eagerLoadRelations()`, so the aliases are absent on those paths, as with any eager loading.

The Boost skill and its query builder reference are updated, since they documented these methods as unsupported.

## Why not `$lookup`?

Computing the aggregates inside the parent query with a `$lookup` stage would avoid the extra queries, but it is not possible today, for five reasons.

**The query builder cannot emit a pipeline for a regular `get()`.** It only switches from `find()` to `aggregate()` when `$groups` or `$aggregate` is set (`src/Query/Builder.php:303`), and it has no `$lookup` support at all. Adding one would force every query carrying a `withCount()` through an aggregation pipeline, changing the execution plan of the parent query itself, not just of the aggregate.

**`$lookup` does no BSON type coercion.** Foreign keys are frequently stored as strings while `_id` is an `ObjectId`, to the point that the package documentation recommends casting them with `'author_id' => 'string'`. Eloquent normalizes both sides when matching in PHP, `$lookup` does not, so the counts would silently be `0`. That is precisely the failure mode this PR avoids by throwing on the cases it cannot compute correctly.

**Server compatibility.** A correlated `$lookup` (`let` + `pipeline`), which is what counting without materializing the related documents requires, needs MongoDB 5.0, while CI still covers 4.4. The `localField` / `foreignField` form works on 4.4 but builds the full array of related documents before `$size`, so an unbounded relation can hit the 16 MB document limit or the 100 MB per stage memory limit.

**One pipeline generator per relation type.** `belongsToMany` stores the keys in an array field, `morphToMany` in pivot subdocuments discriminated by a morph type, and `embedsMany` is already part of the parent document. That is four distinct pipeline builders to write and test, instead of reusing the eager loading `match()` logic that already handles those dictionaries.

**Scope.** PHPLARA-93 is the open spike about rewriting the query builder on top of aggregation pipelines. This PR delivers the feature now, at one extra query per aggregate whatever the number of parent documents, and `$lookup` remains the natural follow up: it is the only way to lift the `orderBy()` limitation on an aggregate alias.
