### PR TITLE
Fix invalid BSON regex flags in `DatabasePresenceVerifier::getCount()`

### DIFF
--- a/src/Validation/DatabasePresenceVerifier.php
+++ b/src/Validation/DatabasePresenceVerifier.php
@@ -17,7 +17,7 @@ class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVe
     #[Override]
     public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
     {
-        $query = $this->table($collection)->where($column, new Regex('^' . preg_quote($value) . '$', '/i'));
+        $query = $this->table($collection)->where($column, new Regex('^' . preg_quote($value) . '$', 'i'));
 
         if ($excludeId !== null && $excludeId !== 'NULL') {
             $query->where($idColumn ?: 'id', '<>', $excludeId);

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests;
 
 use Illuminate\Support\Facades\Validator;
+use MongoDB\BSON\Regex;
 use MongoDB\Laravel\Tests\Models\User;
+use MongoDB\Laravel\Validation\DatabasePresenceVerifier;
 
 class ValidationTest extends TestCase
 {
@@ -131,5 +133,45 @@ class ValidationTest extends TestCase
             ['name' => 'exists:users'],
         );
         $this->assertFalse($validator->fails());
+    }
+
+    public function testGetCountBuildsRegexWithValidFlags(): void
+    {
+        $query = new class {
+            public $value;
+
+            public function useWritePdo()
+            {
+                return $this;
+            }
+
+            public function where($column, $value)
+            {
+                $this->value = $value;
+
+                return $this;
+            }
+
+            public function count()
+            {
+                return 0;
+            }
+        };
+
+        $verifier = new class ($query) extends DatabasePresenceVerifier {
+            public function __construct(private $query)
+            {
+            }
+
+            protected function table($table)
+            {
+                return $this->query;
+            }
+        };
+
+        $verifier->getCount('users', 'name', 'John Doe');
+
+        $this->assertInstanceOf(Regex::class, $query->value);
+        $this->assertSame('i', $query->value->getFlags());
     }
 }


### PR DESCRIPTION
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

## Summary

### Description
`DatabasePresenceVerifier::getCount()` was passing `'/i'` as the flags argument to `MongoDB\BSON\Regex`, instead of the plain PCRE flag character `'i'`. 
`Regex` flags must only contain flag characters (`i`, `m`, `x`, `s`, ...), not a delimiter-style string. 
The sibling method `getMultiCount()` already used the correct `'i'`.

This PR has no observable effect against MongoDB's current PHP driver/server: the BSON encoder silently strips invalid flag characters before a query ever reaches the server (verified by inspecting the actual command sent via `CommandSubscriber`). 
Still, constructing an invalid `Regex` value is incorrect and worth fixing for correctness / forward-compatibility.

### Test Plans
Added `testGetCountBuildsRegexWithValidFlags()` to `ValidationTest.php`.
Since the invalid flags can't be observed end-to-end (see above), the test asserts against the raw `Regex` object passed to `where()`, using a lightweight stub in place of the query builder/connection.

### Checklist

- [ ] Add tests and ensure they pass

### Test Results
```bash
vendor/bin/phpunit tests/ValidationTest.php --testdox
PHPUnit 10.5.47 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.32
Configuration: /var/www/laravel-mongodb/phpunit.xml

...                                                                 3 / 3 (100%)

Time: 00:00.950, Memory: 26.00 MB

Validation (MongoDB\Laravel\Tests\Validation)
 ✔ Unique
 ✔ Exists
 ✔ Get count builds regex with valid flags

OK (3 tests, 19 assertions)
```