### PR TITLE
fix: `morphOne()` using the wrong MorphOne relation class

### DIFF
--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Eloquent;
 
 use Illuminate\Database\Eloquent\Concerns\HasRelationships;
-use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Str;
 use MongoDB\Laravel\Helpers\EloquentBuilder;
@@ -14,6 +13,7 @@ use MongoDB\Laravel\Relations\BelongsToMany;
 use MongoDB\Laravel\Relations\HasMany;
 use MongoDB\Laravel\Relations\HasOne;
 use MongoDB\Laravel\Relations\MorphMany;
+use MongoDB\Laravel\Relations\MorphOne;
 use MongoDB\Laravel\Relations\MorphTo;
 use MongoDB\Laravel\Relations\MorphToMany;
 

--- a/src/Relations/MorphOne.php
+++ b/src/Relations/MorphOne.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Relations;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOne as EloquentMorphOne;
+use Override;
+
+/**
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @extends EloquentMorphOne<TRelatedModel, TDeclaringModel>
+ */
+class MorphOne extends EloquentMorphOne
+{
+    #[Override]
+    protected function whereInMethod(Model $model, $key)
+    {
+        return 'whereIn';
+    }
+}

--- a/tests/Ticket/GH2783Test.php
+++ b/tests/Ticket/GH2783Test.php
@@ -6,6 +6,7 @@ namespace MongoDB\Laravel\Tests\Ticket;
 
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use MongoDB\Laravel\Eloquent\Model;
+use MongoDB\Laravel\Relations\MorphOne as MongoMorphOne;
 use MongoDB\Laravel\Relations\MorphTo;
 use MongoDB\Laravel\Tests\TestCase;
 
@@ -37,6 +38,38 @@ class GH2783Test extends TestCase
         $queriedImageWithUser = GH2783Image::with('imageable')->find($imageWithUser->getKey());
         $this->assertInstanceOf(GH2783User::class, $queriedImageWithUser->imageable);
         $this->assertEquals($user->username, $queriedImageWithUser->imageable->getKey());
+    }
+
+    public function testMorphOneUsesMongoRelationClass()
+    {
+        $post = new GH2783Post();
+
+        $this->assertInstanceOf(MongoMorphOne::class, $post->image());
+    }
+
+    public function testMorphOneEagerLoadWithIntegerKeyType()
+    {
+        // Only reproduces with an integer $keyType: Relation::whereInMethod() resolves to whereIntegerInRaw(),
+        // when eager loading multiple parents　whose primary key is an integer and MongoDB\Laravel\Query\Builder does not support that method. 
+        // String keys (the default for Mongo models) already resolve to whereIn() even with the native class.
+        GH2783IntKeyImage::truncate();
+        GH2783IntKeyPost::truncate();
+
+        $post1 = GH2783IntKeyPost::create(['_id' => 1, 'text' => 'Lorem ipsum']);
+        $post2 = GH2783IntKeyPost::create(['_id' => 2, 'text' => 'Dolor sit amet']);
+
+        $image1 = GH2783IntKeyImage::create(['uri' => 'http://example.com/1.png']);
+        $image1->imageable()->associate($post1)->save();
+
+        $image2 = GH2783IntKeyImage::create(['uri' => 'http://example.com/2.png']);
+        $image2->imageable()->associate($post2)->save();
+
+        $posts = GH2783IntKeyPost::with('image')->get();
+
+        $this->assertCount(2, $posts);
+        foreach ($posts as $post) {
+            $this->assertInstanceOf(GH2783IntKeyImage::class, $post->image);
+        }
     }
 }
 
@@ -71,5 +104,29 @@ class GH2783User extends Model
     public function image(): MorphOne
     {
         return $this->morphOne(GH2783Image::class, 'imageable');
+    }
+}
+
+class GH2783IntKeyImage extends Model
+{
+    protected $connection = 'mongodb';
+    protected $fillable = ['uri'];
+
+    public function imageable(): MorphTo
+    {
+        return $this->morphTo(__FUNCTION__, 'imageable_type', 'imageable_id');
+    }
+}
+
+class GH2783IntKeyPost extends Model
+{
+    protected $connection = 'mongodb';
+    protected $fillable = ['_id', 'text'];
+    protected $keyType = 'int';
+    public $incrementing = false;
+
+    public function image(): MorphOne
+    {
+        return $this->morphOne(GH2783IntKeyImage::class, 'imageable');
     }
 }

--- a/tests/Ticket/GH2783Test.php
+++ b/tests/Ticket/GH2783Test.php
@@ -50,7 +50,7 @@ class GH2783Test extends TestCase
     public function testMorphOneEagerLoadWithIntegerKeyType()
     {
         // Only reproduces with an integer $keyType: Relation::whereInMethod() resolves to whereIntegerInRaw(),
-        // when eager loading multiple parents　whose primary key is an integer and MongoDB\Laravel\Query\Builder does not support that method. 
+        // when eager loading multiple parents whose primary key is an integer and MongoDB\Laravel\Query\Builder does not support that method.
         // String keys (the default for Mongo models) already resolve to whereIn() even with the native class.
         GH2783IntKeyImage::truncate();
         GH2783IntKeyPost::truncate();


### PR DESCRIPTION
## Summary

- Fix `morphOne()` instantiating the native `MorphOne` relation instead of a MongoDB-specific one, which threw `BadMethodCallException` when eager loading with an integer parent key type.

### what I have done

- Added `MongoDB\Laravel\Relations\MorphOne`, mirroring the existing `MorphMany` override, which always resolves `whereInMethod()` to `whereIn()`.
- Updated `HybridRelations::morphOne()` to use this MongoDB-specific class instead of `Illuminate\Database\Eloquent\Relations\MorphOne`.
- Added two regression tests to `tests/Ticket/GH2783Test.php`:
  - `testMorphOneUsesMongoRelationClass` — asserts `morphOne()` returns the MongoDB-specific relation class.
  - `testMorphOneEagerLoadWithIntegerKeyType` — reproduces the eager-load failure end-to-end with an integer `$keyType` parent.

### Motivation

`HybridRelations::morphOne()` already branched on `isDocumentModel()` like its sibling relation methods (`hasOne`, `hasMany`, `morphMany`, ...), but still instantiated the native `Illuminate\Database\Eloquent\Relations\MorphOne`. 
That class's `whereInMethod()` resolves to `whereIntegerInRaw()` when eager loading multiple parents with an integer `$keyType`, and `MongoDB\Laravel\Query\Builder` does not support that method (it's intentionally unsupported, since MongoDB has no bind-parameter concept to optimize around), causing a `BadMethodCallException`. 
String keys, the default for Mongo models, were unaffected either way, which is why this went unnoticed until now.

### Test Plans

- Run `tests/Ticket/GH2783Test.php` against a MongoDB instance and confirm both new regression tests pass, along with the existing tests in the file.
- Confirm the full test suite still passes with no regressions.

### Checklist

- [x] Add tests and ensure they pass

### Test Results
```bash
root@27ca77bae12d:/var/www/laravel-mongodb# vendor/bin/phpunit tests/ValidationTest.php tests/Ticket/GH2783Test.php --filter 'testGetCountBuildsRegexWithValidFlags|testMorphOneUsesMongoRelationClass|testMorphOneEagerLoadWithIntegerKeyType' --testdox
PHPUnit 11.5.56 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.32
Configuration: /var/www/laravel-mongodb/phpunit.xml

..                                                                  2 / 2 (100%)

Time: 00:03.765, Memory: 32.00 MB

GH2783 (MongoDB\Laravel\Tests\Ticket\GH2783)
 ✔ Morph one uses mongo relation class
 ✔ Morph one eager load with integer key type

OK, but there were issues!
Tests: 2, Assertions: 4, PHPUnit Deprecations: 1.
root@27ca77bae12d:/var/www/laravel-mongodb# 
```