### PR TITLE
PHPLARA-250 Keep numeric string relation keys as strings in has queries

### DIFF
--- a/src/Helpers/QueriesRelationships.php
+++ b/src/Helpers/QueriesRelationships.php
@@ -16,7 +16,6 @@ use LogicException;
 use MongoDB\Laravel\Eloquent\Model;
 use MongoDB\Laravel\Relations\MorphToMany;
 
-use function array_count_values;
 use function array_filter;
 use function array_keys;
 use function array_map;
@@ -24,6 +23,7 @@ use function class_basename;
 use function collect;
 use function in_array;
 use function is_array;
+use function is_int;
 use function is_object;
 use function is_string;
 use function method_exists;
@@ -203,17 +203,26 @@ trait QueriesRelationships
     {
         $ids = is_array($relations) ? $relations : $relations->flatten()->toArray();
 
-        $originalIds = [];
+        // Count by type plus value so int 1 and string "1" stay distinct, then
+        // restore the original scalar (or ObjectId hex) for the Mongo $in match.
+        $idsByTypedKey = [];
+        $relationCount = [];
         foreach ($ids as $id) {
-            $key = (string) $id;
-            if (! isset($originalIds[$key])) {
-                $originalIds[$key] = is_object($id) ? $key : $id;
+            if (is_int($id)) {
+                $typedKey = 'i:' . $id;
+                $original = $id;
+            } elseif (is_object($id)) {
+                $typedKey = 's:' . (string) $id;
+                $original = (string) $id;
+            } else {
+                $typedKey = 's:' . (string) $id;
+                $original = $id;
             }
+
+            $idsByTypedKey[$typedKey] = $original;
+            $relationCount[$typedKey] = ($relationCount[$typedKey] ?? 0) + 1;
         }
 
-        $relationCount = array_count_values(array_map(function ($id) {
-            return (string) $id; // Convert Back ObjectIds to Strings
-        }, $ids));
         // Remove unwanted related objects based on the operator and count.
         $relationCount = array_filter($relationCount, function ($counted) use ($count, $operator) {
             // If we are comparing to 0, we always need all results.
@@ -236,7 +245,7 @@ trait QueriesRelationships
 
         // All related ids.
         return array_map(
-            static fn ($key) => $originalIds[(string) $key],
+            static fn ($key) => $idsByTypedKey[$key],
             array_keys($relationCount),
         );
     }

--- a/src/Helpers/QueriesRelationships.php
+++ b/src/Helpers/QueriesRelationships.php
@@ -24,6 +24,7 @@ use function class_basename;
 use function collect;
 use function in_array;
 use function is_array;
+use function is_object;
 use function is_string;
 use function method_exists;
 use function str_contains;
@@ -200,9 +201,19 @@ trait QueriesRelationships
      */
     protected function getConstrainedRelatedIds($relations, $operator, $count)
     {
+        $ids = is_array($relations) ? $relations : $relations->flatten()->toArray();
+
+        $originalIds = [];
+        foreach ($ids as $id) {
+            $key = (string) $id;
+            if (! isset($originalIds[$key])) {
+                $originalIds[$key] = is_object($id) ? $key : $id;
+            }
+        }
+
         $relationCount = array_count_values(array_map(function ($id) {
             return (string) $id; // Convert Back ObjectIds to Strings
-        }, is_array($relations) ? $relations : $relations->flatten()->toArray()));
+        }, $ids));
         // Remove unwanted related objects based on the operator and count.
         $relationCount = array_filter($relationCount, function ($counted) use ($count, $operator) {
             // If we are comparing to 0, we always need all results.
@@ -224,8 +235,10 @@ trait QueriesRelationships
         });
 
         // All related ids.
-        // PHP casts numeric string array keys to integers; stringify so MongoDB $in matches BSON strings.
-        return array_map('strval', array_keys($relationCount));
+        return array_map(
+            static fn ($key) => $originalIds[(string) $key],
+            array_keys($relationCount),
+        );
     }
 
     /**

--- a/src/Helpers/QueriesRelationships.php
+++ b/src/Helpers/QueriesRelationships.php
@@ -224,7 +224,8 @@ trait QueriesRelationships
         });
 
         // All related ids.
-        return array_keys($relationCount);
+        // PHP casts numeric string array keys to integers; stringify so MongoDB $in matches BSON strings.
+        return array_map('strval', array_keys($relationCount));
     }
 
     /**

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -84,6 +84,11 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         return $this->hasMany(Item::class);
     }
 
+    public function itemsWithCustomKey()
+    {
+        return $this->hasMany(Item::class, 'parent_key', 'custom_key');
+    }
+
     public function role()
     {
         return $this->hasOne(Role::class);

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -1181,6 +1181,24 @@ class RelationsTest extends TestCase
         $this->assertCount(1, $authors);
     }
 
+    public function testHasManyHasWithNumericStringCustomKeys(): void
+    {
+        $parent = User::create(['name' => 'Numeric Parent', 'custom_key' => '1']);
+        User::create(['name' => 'No Children', 'custom_key' => '2']);
+        Item::create(['type' => 'child', 'parent_key' => '1']);
+
+        $this->assertCount(1, $parent->itemsWithCustomKey);
+        $this->assertSame(1, $parent->itemsWithCustomKey()->count());
+
+        $parents = User::has('itemsWithCustomKey')->get();
+        $this->assertCount(1, $parents);
+        $this->assertEquals('Numeric Parent', $parents[0]->name);
+
+        $parents = User::whereHas('itemsWithCustomKey')->get();
+        $this->assertCount(1, $parents);
+        $this->assertEquals('Numeric Parent', $parents[0]->name);
+    }
+
     public function testHasOneHas(): void
     {
         $user1 = User::create(['name' => 'John Doe']);

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -1199,6 +1199,47 @@ class RelationsTest extends TestCase
         $this->assertEquals('Numeric Parent', $parents[0]->name);
     }
 
+    public function testHasManyHasWithIntegerCustomKeys(): void
+    {
+        $parent = User::create(['name' => 'Integer Parent', 'custom_key' => 7]);
+        User::create(['name' => 'No Children', 'custom_key' => 8]);
+        Item::create(['type' => 'child', 'parent_key' => 7]);
+
+        $this->assertCount(1, $parent->itemsWithCustomKey);
+        $this->assertSame(1, $parent->itemsWithCustomKey()->count());
+
+        $parents = User::has('itemsWithCustomKey')->get();
+        $this->assertCount(1, $parents);
+        $this->assertSame('Integer Parent', $parents[0]->name);
+
+        $parents = User::whereHas('itemsWithCustomKey')->get();
+        $this->assertCount(1, $parents);
+        $this->assertSame('Integer Parent', $parents[0]->name);
+    }
+
+    public function testHasManyHasWithMixedIntegerAndStringCustomKeys(): void
+    {
+        User::create(['name' => 'String Parent', 'custom_key' => '1']);
+        User::create(['name' => 'Integer Parent', 'custom_key' => 1]);
+        Item::create(['type' => 'child', 'parent_key' => '1']);
+        Item::create(['type' => 'child', 'parent_key' => 1]);
+
+        $names = User::has('itemsWithCustomKey')->get()->pluck('name')->sort()->values()->all();
+
+        $this->assertSame(['Integer Parent', 'String Parent'], $names);
+    }
+
+    public function testHasManyHasCountIgnoresRelatedIdsOfAnotherType(): void
+    {
+        $parent = User::create(['name' => 'String Parent', 'custom_key' => '1']);
+        Item::create(['type' => 'child', 'parent_key' => '1']);
+        Item::create(['type' => 'child', 'parent_key' => 1]);
+
+        $this->assertSame(1, $parent->itemsWithCustomKey()->count());
+        $this->assertCount(0, User::has('itemsWithCustomKey', '>=', 2)->get());
+        $this->assertCount(1, User::has('itemsWithCustomKey', '=', 1)->get());
+    }
+
     public function testHasOneHas(): void
     {
         $user1 = User::create(['name' => 'John Doe']);


### PR DESCRIPTION
Fixes #3541

has() and whereHas() collect related ids with array_count_values then array_keys. PHP promotes numeric string keys to integers, so the MongoDB $in query used integers against stored BSON strings and returned no documents.

This change stringifies the returned keys so values like "1" stay strings.

### Checklist

* [x] Add tests and ensure they pass