### PR TITLE
Fix morphs() support on MongoDB schema blueprints

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -404,6 +404,18 @@ class Blueprint extends BaseBlueprint
         return $this;
     }
 
+    /** @inheritdoc */
+    #[Override]
+    public function after($column, $callback = null)
+    {
+        // Laravel column builders chain after() onto addColumn. MongoDB has no column order.
+        if ($callback instanceof Closure) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
     /**
      * Specify a sparse and unique index for the collection.
      *

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -324,6 +324,17 @@ class SchemaTest extends TestCase
         $this->assertEquals(1, $index['key']['token']);
     }
 
+    public function testMorphs(): void
+    {
+        Schema::create(self::COLL_1, function ($collection) {
+            $collection->morphs('tokenable');
+        });
+
+        $index = $this->assertIndexExists(self::COLL_1, 'tokenable_type_1_tokenable_id_1');
+        $this->assertEquals(1, $index['key']['tokenable_type']);
+        $this->assertEquals(1, $index['key']['tokenable_id']);
+    }
+
     public function testGeospatial(): void
     {
         Schema::table(self::COLL_1, function ($collection) {


### PR DESCRIPTION
Laravel 12 morphs chains after onto addColumn. MongoDB addColumn returns the blueprint, so the inherited after method expected a callback and threw. after now accepts a single column argument as a no op because MongoDB has no column order. The two argument callback form still runs the callback.

Fixes #3444

### Checklist

[x] Add tests and ensure they pass