### PR TITLE
Fix .gitattributes to include skills

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@
 docker-compose.yml       export-ignore
 Dockerfile               export-ignore
 phpstan-baseline.neon    export-ignore
+/resources/**/*.md       -export-ignore


### PR DESCRIPTION
.md files were ignored for export as per .gitattributes rules, assuming that markdown files are purely for documentation. Now though, we have skills living in the boost resources directory. As a result of the .gitattributes rule, those were therefore never pulled when the package was required.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

### Checklist

- [ ] ~~Add tests and ensure they pass~~ (not applicable)
