### PR TITLE
test: verify `transactionLevel()` reflects the active transaction insid…

### DIFF
--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -13,6 +13,8 @@ use MongoDB\Laravel\Eloquent\Model;
 use MongoDB\Laravel\Tests\Models\User;
 use RuntimeException;
 
+use function assert;
+
 class TransactionTest extends TestCase
 {
     public function setUp(): void
@@ -336,6 +338,22 @@ class TransactionTest extends TestCase
 
         $this->assertTrue(User::where('name', 'alcaeus')->exists());
         $this->assertTrue(User::where(['name' => 'klinson'])->where('age', 21)->exists());
+    }
+
+    public function testTransactionLevelInsideClosure(): void
+    {
+        $connection = DB::connection('mongodb');
+        assert($connection instanceof Connection);
+
+        $this->assertSame(0, $connection->transactionLevel());
+
+        $levelInsideClosure = null;
+        $connection->transaction(function () use ($connection, &$levelInsideClosure): void {
+            $levelInsideClosure = $connection->transactionLevel();
+        });
+
+        $this->assertSame(1, $levelInsideClosure);
+        $this->assertSame(0, $connection->transactionLevel());
     }
 
     public function testTransactionRepeatsOnTransientFailure(): void


### PR DESCRIPTION
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

### Motivation
[PHPLARA-29](https://jira.mongodb.org/browse/PHPLARA-29) / [GH-2851](https://github.com/mongodb/laravel-mongodb/issues/2851)

Reported that `Connection::transactionLevel()` returned `0` from inside the closure passed to `transaction()`, because the old implementation never set `$this->transactions` before invoking the callback.
And `transaction()` now calls `handleInitialTransactionState()` (which sets `$this->transactions = 1`) before invoking the callback, so this is already fixed as a side effect of later work on transaction event handling.

No production code change is needed.

### What I have done

- Add `testTransactionLevelInsideClosure()` to `tests/TransactionTest.php` to lock in the current (correct) behaviour and close out the ticket.

### Checklist

- [x] Add tests and ensure they pass
