### PR TITLE
PHPLARA-262 Support serializable classes allowlist in MongoStore cache

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,7 +61,7 @@ parameters:
 			path: src/Relations/MorphToMany.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Support\\HigherOrderCollectionProxy\<\(int\|string\), Illuminate\\Database\\Eloquent\\Model\>\:\:pushSoftDeleteMetadata\(\)\.$#'
+			message: '#^Call to an undefined method Illuminate\\Support\\HigherOrderCollectionProxy\<.+?\>\:\:pushSoftDeleteMetadata\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Scout/ScoutEngine.php

--- a/resources/boost/skills/laravel-mongodb/references/cache-sessions.md
+++ b/resources/boost/skills/laravel-mongodb/references/cache-sessions.md
@@ -7,6 +7,10 @@
 return [
     'default' => env('CACHE_STORE', 'mongodb'),
 
+    // Optional: restrict which classes may be unserialized from the cache.
+    // null allows all, false (shown here) allows none, or list allowed classes.
+    'serializable_classes' => false,
+
     'stores' => [
         'mongodb' => [
             'driver'          => 'mongodb',

--- a/src/Cache/MongoStore.php
+++ b/src/Cache/MongoStore.php
@@ -35,6 +35,7 @@ final class MongoStore implements LockProvider, Store
      * @param string          $lockCollectionName          Name of the collection where locks are stored
      * @param array{int, int} $lockLottery                 Probability [chance, total] of pruning expired cache items. Set to [0, 0] to disable
      * @param int             $defaultLockTimeoutInSeconds Time-to-live of the locks in seconds
+     * @param array|bool|null $serializableClasses         Classes allowed during unserialization, null to allow all classes
      */
     public function __construct(
         private readonly Connection $connection,
@@ -44,6 +45,7 @@ final class MongoStore implements LockProvider, Store
         private readonly string $lockCollectionName = 'cache_locks',
         private readonly array $lockLottery = [2, 100],
         private readonly int $defaultLockTimeoutInSeconds = 86400,
+        private readonly array|bool|null $serializableClasses = null,
     ) {
         $this->collection = $this->connection->getCollection($this->collectionName);
     }
@@ -313,6 +315,10 @@ final class MongoStore implements LockProvider, Store
     {
         if (! is_string($value)) {
             return $value;
+        }
+
+        if ($this->serializableClasses !== null) {
+            return unserialize($value, ['allowed_classes' => $this->serializableClasses]);
         }
 
         return unserialize($value);

--- a/src/MongoDBServiceProvider.php
+++ b/src/MongoDBServiceProvider.php
@@ -93,6 +93,7 @@ class MongoDBServiceProvider extends ServiceProvider
                     $config['lock_collection'] ?? ($config['collection'] ?? 'cache') . '_locks',
                     $config['lock_lottery'] ?? [2, 100],
                     $config['lock_timeout'] ?? 86400,
+                    $app['config']->get('cache.serializable_classes'),
                 );
 
                 return $cache->repository($store, $config);

--- a/tests/Cache/MongoCacheStoreTest.php
+++ b/tests/Cache/MongoCacheStoreTest.php
@@ -2,6 +2,7 @@
 
 namespace MongoDB\Laravel\Tests\Cache;
 
+use __PHP_Incomplete_Class;
 use Generator;
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Carbon;
@@ -284,6 +285,45 @@ class MongoCacheStoreTest extends TestCase
         $this->assertEquals($value, $result);
     }
 
+    public function testGetUnserializesAnyClassByDefault()
+    {
+        $store = $this->getStore();
+
+        $this->assertTrue($store->put('foo', new stdClass(), 60));
+        $this->assertInstanceOf(stdClass::class, $store->get('foo'));
+    }
+
+    public function testGetAllowsNoClassWhenSerializableClassesIsFalse()
+    {
+        $store = $this->getStoreAllowing(false);
+
+        $this->assertTrue($store->put('foo', new stdClass(), 60));
+        $this->assertInstanceOf(__PHP_Incomplete_Class::class, $store->get('foo'));
+    }
+
+    public function testGetOnlyUnserializesAllowedClasses()
+    {
+        $store = $this->getStoreAllowing([stdClass::class]);
+
+        $this->assertTrue($store->put('allowed', new stdClass(), 60));
+        $this->assertTrue($store->put('denied', Carbon::now(), 60));
+
+        $this->assertInstanceOf(stdClass::class, $store->get('allowed'));
+        $this->assertInstanceOf(__PHP_Incomplete_Class::class, $store->get('denied'));
+    }
+
+    #[DataProvider('provideSerializedEdgeCases')]
+    public function testGetReturnsCachedValueForSerializedEdgeCasesWithAllowedClasses(mixed $value): void
+    {
+        $store = $this->getStoreAllowing([stdClass::class]);
+
+        $this->assertTrue($store->put('foo', $value, 60));
+
+        $result = $store->get('foo');
+        $this->assertSame(get_debug_type($value), get_debug_type($result));
+        $this->assertEquals($value, $result);
+    }
+
     public function testTTLIndex()
     {
         $store = $this->getStore();
@@ -300,6 +340,14 @@ class MongoCacheStoreTest extends TestCase
         assert($repository instanceof Repository);
 
         return $repository;
+    }
+
+    private function getStoreAllowing(array|bool $serializableClasses): Repository
+    {
+        config()->set('cache.serializable_classes', $serializableClasses);
+        Cache::purge('mongodb');
+
+        return $this->getStore();
     }
 
     private function getCacheCollectionName(): string


### PR DESCRIPTION
Laravel added an opt-in allowlist of classes that cache stores may instantiate while unserializing, configured with cache.serializable_classes. MongoStore was the last store not honouring it, so applications hardening their cache had a gap they could not close.

The default stays unrestricted, so existing behaviour is unchanged.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

### Checklist

- [x] Add tests and ensure they pass
