### PR TITLE
Merge 5.9 into 5.x

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,9 +25,14 @@ parameters:
             path: src/MongoDBServiceProvider.php
             count: 1
             reportUnmatched: false
-        # resolveClassAttribute() requires Laravel 13, which is not installable on PHP 8.2.
+        # The Table attribute and resolveClassAttribute() require Laravel 13,
+        # which is not installable on PHP 8.2.
         -
             identifier: staticMethod.notFound
+            path: src/Eloquent/DocumentModel.php
+            reportUnmatched: false
+        -
+            message: '#Class Illuminate\\Database\\Eloquent\\Attributes\\Table not found\.#'
             path: src/Eloquent/DocumentModel.php
             reportUnmatched: false
         # The "query" and "model" parameters of vectorSearch() require mongodb/mongodb 2.4+,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,6 +25,11 @@ parameters:
             path: src/MongoDBServiceProvider.php
             count: 1
             reportUnmatched: false
+        # resolveClassAttribute() requires Laravel 13, which is not installable on PHP 8.2.
+        -
+            identifier: staticMethod.notFound
+            path: src/Eloquent/DocumentModel.php
+            reportUnmatched: false
         # The "query" and "model" parameters of vectorSearch() require mongodb/mongodb 2.4+,
         # not yet available in the version currently installed.
         -

--- a/src/Validation/DatabasePresenceVerifier.php
+++ b/src/Validation/DatabasePresenceVerifier.php
@@ -17,7 +17,7 @@ class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVe
     #[Override]
     public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
     {
-        $query = $this->table($collection)->where($column, new Regex('^' . preg_quote($value) . '$', '/i'));
+        $query = $this->table($collection)->where($column, new Regex('^' . preg_quote($value) . '$', 'i'));
 
         if ($excludeId !== null && $excludeId !== 'NULL') {
             $query->where($idColumn ?: 'id', '<>', $excludeId);

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests;
 
 use Illuminate\Support\Facades\Validator;
+use MongoDB\BSON\Regex;
 use MongoDB\Laravel\Tests\Models\User;
+use MongoDB\Laravel\Validation\DatabasePresenceVerifier;
 
 class ValidationTest extends TestCase
 {
@@ -131,5 +133,45 @@ class ValidationTest extends TestCase
             ['name' => 'exists:users'],
         );
         $this->assertFalse($validator->fails());
+    }
+
+    public function testGetCountBuildsRegexWithValidFlags(): void
+    {
+        $query = new class {
+            public $value;
+
+            public function useWritePdo()
+            {
+                return $this;
+            }
+
+            public function where($column, $value)
+            {
+                $this->value = $value;
+
+                return $this;
+            }
+
+            public function count()
+            {
+                return 0;
+            }
+        };
+
+        $verifier = new class ($query) extends DatabasePresenceVerifier {
+            public function __construct(private $query)
+            {
+            }
+
+            protected function table($table)
+            {
+                return $this->query;
+            }
+        };
+
+        $verifier->getCount('users', 'name', 'John Doe');
+
+        $this->assertInstanceOf(Regex::class, $query->value);
+        $this->assertSame('i', $query->value->getFlags());
     }
 }


### PR DESCRIPTION
Merges `5.9` into `5.x` ahead of the 5.10.0 release.

Brings over the one commit on `5.9` that is not yet on `5.x`:

- Fix invalid BSON regex flags in `DatabasePresenceVerifier::getCount()` (#3563)

The merge was clean (no conflicts). `5.9` was never released as 5.9.2 — this fix ships in 5.10.0 instead.