### PR TITLE
Scope static analysis caches per PHP version and driver

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -48,24 +48,28 @@ jobs:
           extensions: curl,mbstring
           tools: composer:v2
 
-      - name: Cache dependencies
+      - name: Get Composer cache directory
         id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer downloads
         uses: actions/cache@v6
         with:
-          path: ./vendor
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: composer-${{ matrix.php }}-${{ matrix.driver }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: composer-${{ matrix.php }}-${{ matrix.driver }}-
 
       - name: Install dependencies
-        run: composer install
+        run: composer update --no-interaction
 
       - name: Restore cache PHPStan results
         id: phpstan-cache-restore
         uses: actions/cache/restore@v6
         with:
           path: .cache
-          key: phpstan-result-cache-${{ matrix.php }}-${{ github.run_id }}
+          key: phpstan-result-cache-${{ matrix.php }}-${{ matrix.driver }}-${{ github.run_id }}
           restore-keys: |
-            phpstan-result-cache-${{ matrix.php }}-
+            phpstan-result-cache-${{ matrix.php }}-${{ matrix.driver }}-
 
       - name: Run PHPStan
         id: phpstan

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ./vendor
-          key: composer-${{ hashFiles('**/composer.lock') }}
+          key: composer-${{ matrix.php }}-${{ matrix.driver }}-${{ hashFiles('**/composer.json') }}
 
       - name: Install dependencies
         run: composer install
@@ -65,7 +65,7 @@ jobs:
           path: .cache
           key: phpstan-result-cache-${{ matrix.php }}-${{ github.run_id }}
           restore-keys: |
-            phpstan-result-cache-
+            phpstan-result-cache-${{ matrix.php }}-
 
       - name: Run PHPStan
         id: phpstan

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,7 +61,7 @@ parameters:
 			path: src/Relations/MorphToMany.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Support\\HigherOrderCollectionProxy\<\(int\|string\), Illuminate\\Database\\Eloquent\\Model\>\:\:pushSoftDeleteMetadata\(\)\.$#'
+			message: '#^Call to an undefined method Illuminate\\Support\\HigherOrderCollectionProxy\<.+?\>\:\:pushSoftDeleteMetadata\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Scout/ScoutEngine.php


### PR DESCRIPTION
The `vendor` cache in `static-analysis.yml` was keyed on `composer-${{ hashFiles('**/composer.lock') }}`, but `composer.lock` is gitignored, so `hashFiles()` resolves to an empty string. Every matrix job, on every commit, shared the single cache entry `composer-`, which was also never invalidated when dependencies changed.

Jobs therefore restored a `vendor` directory resolved for a different PHP version, and composer had to fix it up during install. In [run 33612190080](https://github.com/mongodb/laravel-mongodb/actions/runs/33612190080) the PHP 8.2 job downgraded `symfony/error-handler` from v8.1.0 to v7.4.17 for this reason.

The PHPStan result cache had the same problem one level down: the `phpstan-result-cache-` restore key let the 8.2 job restore the 8.5 result cache.

## Original approach

Initially this re-keyed `vendor` per PHP version and driver and kept `composer install`. Following @GromNaN's review, the approach changed (see below).

## Revised approach (per review feedback)

**Dependencies:** Instead of caching `./vendor` and running `composer install`, this now mirrors `build-ci.yml`: it caches Composer's download directory (`cache-files-dir`) and runs `composer update --no-interaction`. Each run therefore resolves the **latest** matching dependencies — so CI catches breaking changes in Laravel and other packages as soon as they are released — while still avoiding re-downloading packages. The cache is keyed by `matrix.php`, `matrix.driver`, and `hashFiles('**/composer.json')` (there is no committed lock file), with a `restore-keys` prefix for partial hits.

**PHPStan result cache:** Keyed and restored by `matrix.php` **and** `matrix.driver`, so the PHP 8.4 × driver 1 and PHP 8.4 × driver 2 jobs no longer share a result cache.

Noticed while investigating the PHP 8.2 static analysis failures; not the cause of those (that is fixed separately in #3574).
