### PR TITLE
PHPLARA-261 Wrap the cache lock owner in a literal expression

### DIFF
--- a/src/Cache/MongoLock.php
+++ b/src/Cache/MongoLock.php
@@ -49,7 +49,7 @@ final class MongoLock extends Lock
         $isExpiredOrAlreadyOwned = [
             '$or' => [
                 ['$lte' => ['$expires_at', $this->getUTCDateTime()]],
-                ['$eq' => ['$owner', $this->owner]],
+                ['$eq' => ['$owner', ['$literal' => $this->owner]]],
             ],
         ];
         $result = $this->collection->findOneAndUpdate(
@@ -60,7 +60,7 @@ final class MongoLock extends Lock
                         'owner' => [
                             '$cond' => [
                                 'if' => $isExpiredOrAlreadyOwned,
-                                'then' => $this->owner,
+                                'then' => ['$literal' => $this->owner],
                                 'else' => '$owner',
                             ],
                         ],

--- a/tests/Cache/MongoLockTest.php
+++ b/tests/Cache/MongoLockTest.php
@@ -134,6 +134,38 @@ class MongoLockTest extends TestCase
         $this->assertFalse($resoredLock->isOwnedByCurrentProcess());
     }
 
+    #[TestWith(['$owner'])]
+    #[TestWith(['$literal'])]
+    #[TestWith(['$$ROOT'])]
+    public function testAcquireCannotTakeOverAnotherOwnersLockWithADollarPrefixedOwner(string $maliciousOwner): void
+    {
+        $lock = $this->getCache()->lock('foo', 100, 'legit-owner');
+        $this->assertTrue($lock->get());
+
+        $attackerLock = $this->getCache()->lock('foo', 1, $maliciousOwner);
+        $this->assertFalse($attackerLock->acquire());
+
+        $this->assertTrue($lock->isOwnedByCurrentProcess());
+
+        $attackerLock->release();
+        $lock->release();
+    }
+
+    #[TestWith(['$owner'])]
+    #[TestWith(['$literal'])]
+    #[TestWith(['$$ROOT'])]
+    public function testAcquireStoresADollarPrefixedOwnerAsALiteralValue(string $owner): void
+    {
+        $lock = $this->getCache()->lock('foo', 10, $owner);
+        $this->assertTrue($lock->get());
+        $this->assertSame($owner, $lock->owner());
+
+        $restoredLock = $this->getCache()->restoreLock('foo', $owner);
+        $this->assertTrue($restoredLock->isOwnedByCurrentProcess());
+
+        $restoredLock->release();
+    }
+
     public function testTTLIndex()
     {
         $store = $this->getCache()->lock('')->createTTLIndex();


### PR DESCRIPTION
MongoLock::acquire() builds an aggregation-pipeline update where the lock owner string is embedded inside $eq and $cond expressions. When the owner string starts with a dollar sign, MongoDB reads it as a field-path expression instead of a literal value, which changes the ownership and expiry checks that decide whether a lock is acquired.

The owner value is now wrapped in $literal at both usage sites so it is always compared and stored as a literal string. Regression tests cover acquire, restoreLock, and getCurrentOwner with dollar-prefixed owner values.
