### PR TITLE
PHPLARA-265 Reject a MongoDB operator as a scalar id or relation key

### DIFF
--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -270,9 +270,13 @@ trait DocumentModel
             };
         }
 
-        // Convert _id to ObjectID.
-        if (($key === '_id' || $key === 'id') && is_string($value) && strlen($value) === 24) {
-            $value = $this->newBaseQueryBuilder()->convertKey($value);
+        // Reject a MongoDB operator planted as the primary key, then convert _id to ObjectID.
+        if ($key === '_id' || $key === 'id') {
+            QueryBuilder::assertKeyIsNotOperator($value);
+
+            if (is_string($value) && strlen($value) === 24) {
+                $value = $this->newBaseQueryBuilder()->convertKey($value);
+            }
         }
 
         // Support keys in dot notation.

--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -270,7 +270,7 @@ trait DocumentModel
             };
         }
 
-        // Reject a MongoDB operator planted as the primary key, then convert _id to ObjectID.
+        // Reject a MongoDB operator as a primary key, then convert _id to ObjectID.
         if ($key === '_id' || $key === 'id') {
             QueryBuilder::assertKeyIsNotOperator($value);
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1240,11 +1240,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Ensure a value used as a document id or relation key does not smuggle a MongoDB
-     * operator. A "$"-prefixed key (at any depth) would turn an intended literal match
-     * into an arbitrary query predicate, e.g. {_id: {$ne: null}} matching every document.
-     *
-     * A plain array without operator keys is allowed, so composite _id values keep working.
+     * A plain array without "$"-prefixed keys is allowed, so composite _id values keep working.
      *
      * @internal
      *

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -89,10 +89,7 @@ class Builder extends BaseBuilder
 {
     private const REGEX_DELIMITERS = ['/', '#', '~'];
 
-    /**
-     * Sentinel operator that is used instead of "=" that doesn't get converted
-     * to $eq when the value contains a MQL query operator.
-     */
+    /** Internal sentinel so array-of-wheres calls skip the $eq hardening. */
     private const UNSAFE_FIELD_QUERY = 'unsafe-field-query';
 
     /**
@@ -1231,15 +1228,7 @@ class Builder extends BaseBuilder
         return $this->castKey($id);
     }
 
-    /**
-     * Convert a key to its native BSON type without rejecting operator arrays.
-     * Embedded id fields accept operator documents such as {"$exists": true},
-     * so the primary-key check lives in convertKey().
-     *
-     * @param  mixed $id
-     *
-     * @return mixed
-     */
+    /** Convert a key to its native BSON type without the primary-key operator check. */
     private function castKey($id)
     {
         if (is_string($id) && strlen($id) === 24 && ctype_xdigit($id)) {
@@ -1311,8 +1300,6 @@ class Builder extends BaseBuilder
             if ($operator === self::UNSAFE_FIELD_QUERY) {
                 $operator = '=';
             } elseif ($operator === '=' && self::valueContainsOperator($params[2])) {
-                // Identifier columns only accept a scalar or a plain array (composite id).
-                // Reject an operator array here, and leave the non-id path to $eq below.
                 if (is_string($params[0]) && $this->isIdLikeField($params[0])) {
                     throw new InvalidArgumentException(sprintf(
                         'The value used as a document id or relation key cannot contain the MongoDB operator "%s".',
@@ -1335,11 +1322,7 @@ class Builder extends BaseBuilder
         return parent::where(...$params);
     }
 
-    /**
-     * The "=" operator of each generated call is an internal detail of the array
-     * shorthand, not an operator chosen by the caller: these calls must build an
-     * operator document like the 2-argument form does, not be hardened into $eq.
-     */
+    /** Array-of-wheres calls are marked so their generated "=" keeps building an operator document. */
     #[Override]
     protected function addArrayOfWheres($column, $boolean, $method = 'where')
     {
@@ -1373,12 +1356,7 @@ class Builder extends BaseBuilder
         return false;
     }
 
-    /**
-     * Whether a where column resolves to the MongoDB document id after the grammar
-     * aliasing: "id" becomes "_id", and "foo.id" becomes "foo._id" when configured.
-     * Operator arrays are rejected on such columns instead of being wrapped in $eq,
-     * so the rejection surfaces the offending operator.
-     */
+    /** Whether the column resolves to the document id after grammar aliasing. */
     private function isIdLikeField(string $column): bool
     {
         $key = array_key_first($this->grammar->prepareFieldsForQuery([$column => null]));
@@ -1386,10 +1364,7 @@ class Builder extends BaseBuilder
         return $key === '_id' || str_ends_with($key, '._id');
     }
 
-    /**
-     * The first "$"-prefixed key found in the value, depth-first, in the same order
-     * as the recursive rejection used for identifiers.
-     */
+    /** First "$"-prefixed key, depth-first, in the same order as assertKeyIsNotOperator(). */
     private static function firstOperatorKey(mixed $value): ?string
     {
         if (! is_array($value)) {
@@ -1444,8 +1419,7 @@ class Builder extends BaseBuilder
                     $this->grammar->prepareFieldsForQuery([$where['column'] => null]),
                 );
 
-                // Convert id's. The primary key rejects operator arrays; embedded id
-                // fields keep the scalar conversion so operator queries stay valid.
+                // Convert id's. The primary key rejects operator arrays; embedded ids keep operator queries.
                 if ($where['column'] === '_id') {
                     if (isset($where['values'])) {
                         // Multiple values.

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1299,13 +1299,8 @@ class Builder extends BaseBuilder
 
             if ($operator === self::UNSAFE_FIELD_QUERY) {
                 $operator = '=';
-            } elseif ($operator === '=' && self::valueContainsOperator($params[2])) {
-                if (is_string($params[0]) && $this->isIdLikeField($params[0])) {
-                    throw new InvalidArgumentException(sprintf(
-                        'The value used as a document id or relation key cannot contain the MongoDB operator "%s".',
-                        self::firstOperatorKey($params[2]),
-                    ));
-                }
+            } elseif ($operator === '=' && self::firstOperatorKey($params[2]) !== null) {
+                $this->throwIfIdLikeOperatorValue($params[0], $params[2]);
 
                 $params[2] = ['$eq' => $params[2]];
             }
@@ -1337,31 +1332,19 @@ class Builder extends BaseBuilder
         }, $boolean);
     }
 
-    private static function valueContainsOperator(mixed $value): bool
-    {
-        if (! is_array($value)) {
-            return false;
-        }
-
-        foreach ($value as $key => $item) {
-            if (is_string($key) && str_starts_with($key, '$')) {
-                return true;
-            }
-
-            if (self::valueContainsOperator($item)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     /** Whether the column resolves to the document id after grammar aliasing. */
     private function isIdLikeField(string $column): bool
     {
         $key = array_key_first($this->grammar->prepareFieldsForQuery([$column => null]));
 
         return $key === '_id' || str_ends_with($key, '._id');
+    }
+
+    private function throwIfIdLikeOperatorValue(mixed $column, mixed $value): void
+    {
+        if (is_string($column) && $this->isIdLikeField($column)) {
+            self::assertKeyIsNotOperator($value);
+        }
     }
 
     /** First "$"-prefixed key, depth-first, in the same order as assertKeyIsNotOperator(). */
@@ -1420,21 +1403,13 @@ class Builder extends BaseBuilder
                 );
 
                 // Convert id's. The primary key rejects operator arrays; embedded ids keep operator queries.
-                if ($where['column'] === '_id') {
+                if ($where['column'] === '_id' || str_ends_with($where['column'], '._id')) {
+                    $convert = $where['column'] === '_id' ? $this->convertKey(...) : $this->castKey(...);
+
                     if (isset($where['values'])) {
-                        // Multiple values.
-                        $where['values'] = array_map($this->convertKey(...), $where['values']);
+                        $where['values'] = array_map($convert, $where['values']);
                     } elseif (isset($where['value'])) {
-                        // Single value.
-                        $where['value'] = $this->convertKey($where['value']);
-                    }
-                } elseif (str_ends_with($where['column'], '._id')) {
-                    if (isset($where['values'])) {
-                        // Multiple values.
-                        $where['values'] = array_map($this->castKey(...), $where['values']);
-                    } elseif (isset($where['value'])) {
-                        // Single value.
-                        $where['value'] = $this->castKey($where['value']);
+                        $where['value'] = $convert($where['value']);
                     }
                 }
             }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1226,6 +1226,8 @@ class Builder extends BaseBuilder
      */
     public function convertKey($id)
     {
+        self::assertKeyIsNotOperator($id);
+
         if (is_string($id) && strlen($id) === 24 && ctype_xdigit($id)) {
             return new ObjectID($id);
         }
@@ -1235,6 +1237,35 @@ class Builder extends BaseBuilder
         }
 
         return $id;
+    }
+
+    /**
+     * Ensure a value used as a document id or relation key does not smuggle a MongoDB
+     * operator. A "$"-prefixed key (at any depth) would turn an intended literal match
+     * into an arbitrary query predicate, e.g. {_id: {$ne: null}} matching every document.
+     *
+     * A plain array without operator keys is allowed, so composite _id values keep working.
+     *
+     * @internal
+     *
+     * @throws InvalidArgumentException when the value contains a MongoDB operator.
+     */
+    public static function assertKeyIsNotOperator(mixed $value): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        foreach ($value as $key => $item) {
+            if (is_string($key) && str_starts_with($key, '$')) {
+                throw new InvalidArgumentException(sprintf(
+                    'The value used as a document id or relation key cannot contain the MongoDB operator "%s".',
+                    $key,
+                ));
+            }
+
+            self::assertKeyIsNotOperator($item);
+        }
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1228,6 +1228,20 @@ class Builder extends BaseBuilder
     {
         self::assertKeyIsNotOperator($id);
 
+        return $this->castKey($id);
+    }
+
+    /**
+     * Convert a key to its native BSON type without rejecting operator arrays.
+     * Embedded id fields accept operator documents such as {"$exists": true},
+     * so the primary-key check lives in convertKey().
+     *
+     * @param  mixed $id
+     *
+     * @return mixed
+     */
+    private function castKey($id)
+    {
         if (is_string($id) && strlen($id) === 24 && ctype_xdigit($id)) {
             return new ObjectID($id);
         }
@@ -1430,14 +1444,23 @@ class Builder extends BaseBuilder
                     $this->grammar->prepareFieldsForQuery([$where['column'] => null]),
                 );
 
-                // Convert id's.
-                if ($where['column'] === '_id' || str_ends_with($where['column'], '._id')) {
+                // Convert id's. The primary key rejects operator arrays; embedded id
+                // fields keep the scalar conversion so operator queries stay valid.
+                if ($where['column'] === '_id') {
                     if (isset($where['values'])) {
                         // Multiple values.
                         $where['values'] = array_map($this->convertKey(...), $where['values']);
                     } elseif (isset($where['value'])) {
                         // Single value.
                         $where['value'] = $this->convertKey($where['value']);
+                    }
+                } elseif (str_ends_with($where['column'], '._id')) {
+                    if (isset($where['values'])) {
+                        // Multiple values.
+                        $where['values'] = array_map($this->castKey(...), $where['values']);
+                    } elseif (isset($where['value'])) {
+                        // Single value.
+                        $where['value'] = $this->castKey($where['value']);
                     }
                 }
             }

--- a/src/Relations/BelongsTo.php
+++ b/src/Relations/BelongsTo.php
@@ -7,6 +7,7 @@ namespace MongoDB\Laravel\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo as EloquentBelongsTo;
+use MongoDB\Laravel\Query\Builder as QueryBuilder;
 use Override;
 
 /**
@@ -34,7 +35,9 @@ class BelongsTo extends EloquentBelongsTo
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $this->query->where($this->ownerKey, '=', $this->parent->{$this->foreignKey});
+            $value = $this->parent->{$this->foreignKey};
+            QueryBuilder::assertKeyIsNotOperator($value);
+            $this->query->where($this->ownerKey, '=', $value);
         }
     }
 

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
 use Illuminate\Support\Arr;
 use MongoDB\Laravel\Eloquent\Model as DocumentModel;
+use MongoDB\Laravel\Query\Builder as QueryBuilder;
 use Override;
 
 use function array_diff;
@@ -88,7 +89,9 @@ class BelongsToMany extends EloquentBelongsToMany
     {
         $foreign = $this->getForeignKey();
 
-        $this->query->where($foreign, '=', $this->parent->{$this->parentKey});
+        $value = $this->parent->{$this->parentKey};
+        QueryBuilder::assertKeyIsNotOperator($value);
+        $this->query->where($foreign, '=', $value);
 
         return $this;
     }

--- a/src/Relations/MorphTo.php
+++ b/src/Relations/MorphTo.php
@@ -6,6 +6,7 @@ namespace MongoDB\Laravel\Relations;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo as EloquentMorphTo;
+use MongoDB\Laravel\Query\Builder as QueryBuilder;
 use Override;
 
 /**
@@ -23,10 +24,12 @@ class MorphTo extends EloquentMorphTo
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
+            $value = $this->getForeignKeyFrom($this->parent);
+            QueryBuilder::assertKeyIsNotOperator($value);
             $this->query->where(
                 $this->ownerKey ?? $this->getForeignKeyName(),
                 '=',
-                $this->getForeignKeyFrom($this->parent),
+                $value,
             );
         }
     }

--- a/src/Relations/MorphToMany.php
+++ b/src/Relations/MorphToMany.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany as EloquentMorphToMany;
 use Illuminate\Support\Arr;
 use MongoDB\BSON\ObjectId;
+use MongoDB\Laravel\Query\Builder as QueryBuilder;
 use Override;
 
 use function array_diff;
@@ -67,6 +68,7 @@ class MorphToMany extends EloquentMorphToMany
         if ($this->getInverse()) {
             $ids = $this->getKeys($models, $this->table);
             $ids = $this->extractIds($ids[0] ?? []);
+            QueryBuilder::assertKeyIsNotOperator($ids);
             $this->query->whereIn($this->relatedKey, $ids);
         } else {
             parent::addEagerConstraints($models);
@@ -86,16 +88,22 @@ class MorphToMany extends EloquentMorphToMany
             if (\MongoDB\Laravel\Eloquent\Model::isDocumentModel($this->parent)) {
                 $ids = $this->extractIds((array) $this->parent->{$this->table});
 
+                QueryBuilder::assertKeyIsNotOperator($ids);
                 $this->query->whereIn($this->relatedKey, $ids);
             } else {
-                $this->query
-                    ->whereIn($this->foreignPivotKey, (array) $this->parent->{$this->parentKey});
+                $ids = (array) $this->parent->{$this->parentKey};
+
+                QueryBuilder::assertKeyIsNotOperator($ids);
+                $this->query->whereIn($this->foreignPivotKey, $ids);
             }
         } else {
-            match (\MongoDB\Laravel\Eloquent\Model::isDocumentModel($this->parent)) {
-                true => $this->query->whereIn($this->relatedKey, (array) $this->parent->{$this->relatedPivotKey}),
-                false => $this->query
-                    ->whereIn($this->getQualifiedForeignPivotKeyName(), (array) $this->parent->{$this->parentKey}),
+            $isDocument = \MongoDB\Laravel\Eloquent\Model::isDocumentModel($this->parent);
+            $ids = (array) ($isDocument ? $this->parent->{$this->relatedPivotKey} : $this->parent->{$this->parentKey});
+
+            QueryBuilder::assertKeyIsNotOperator($ids);
+            match ($isDocument) {
+                true => $this->query->whereIn($this->relatedKey, $ids),
+                false => $this->query->whereIn($this->getQualifiedForeignPivotKeyName(), $ids),
             };
         }
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
@@ -121,6 +122,16 @@ class ModelTest extends TestCase
 
         $this->assertEquals('John Doe', $user->name);
         $this->assertEquals(35, $user->age);
+    }
+
+    public function testRejectOperatorPlantedAsPrimaryKey(): void
+    {
+        $user = new User();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value used as a document id or relation key cannot contain the MongoDB operator "$ne"');
+
+        $user->_id = ['$ne' => null];
     }
 
     public function testInsertNonIncrementable(): void

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1359,6 +1359,12 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->where('id', 1)->orWhere('id', 2),
         ];
 
+        // A composite id (a plain array without MongoDB operators) is a valid _id and must be preserved.
+        yield 'composite array id without operator' => [
+            ['find' => [['_id' => ['tenant' => 1, 'seq' => 2]], []]],
+            fn (Builder $builder) => $builder->where('id', ['tenant' => 1, 'seq' => 2]),
+        ];
+
         yield 'select colums with id alias' => [
             ['find' => [[], ['projection' => ['name' => 1, 'email' => 1, '_id' => 1]]]],
             fn (Builder $builder) => $builder->select('name', 'email', 'id'),
@@ -1672,16 +1678,28 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->where(2.3, '>', 1),
         ];
 
-        yield 'where _id = with operator array is rejected' => [
+        yield 'where _id equals operator document' => [
             InvalidArgumentException::class,
             'The value used as a document id or relation key cannot contain the MongoDB operator "$ne"',
             fn (Builder $builder) => $builder->where('_id', '=', ['$ne' => null]),
         ];
 
-        yield 'where _id = with nested operator array is rejected' => [
+        yield 'where id (alias) with operator document' => [
+            InvalidArgumentException::class,
+            'The value used as a document id or relation key cannot contain the MongoDB operator "$ne"',
+            fn (Builder $builder) => $builder->where('id', ['$ne' => null]),
+        ];
+
+        yield 'where _id with nested operator document' => [
             InvalidArgumentException::class,
             'The value used as a document id or relation key cannot contain the MongoDB operator "$gt"',
             fn (Builder $builder) => $builder->where('_id', '=', ['foo' => ['$gt' => 1]]),
+        ];
+
+        yield 'whereIn _id with operator document element' => [
+            InvalidArgumentException::class,
+            'The value used as a document id or relation key cannot contain the MongoDB operator "$ne"',
+            fn (Builder $builder) => $builder->whereIn('_id', [['$ne' => null]]),
         ];
     }
 

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1365,6 +1365,12 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->where('id', ['tenant' => 1, 'seq' => 2]),
         ];
 
+        // Operator documents stay valid on embedded id fields, e.g. Schema::hasColumn().
+        yield 'where array shorthand with $exists on an embedded id is unchanged' => [
+            ['find' => [['embed._id' => ['$exists' => true]], []]],
+            fn (Builder $builder) => $builder->where(['embed._id' => ['$exists' => true]]),
+        ];
+
         yield 'select colums with id alias' => [
             ['find' => [[], ['projection' => ['name' => 1, 'email' => 1, '_id' => 1]]]],
             fn (Builder $builder) => $builder->select('name', 'email', 'id'),

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1371,6 +1371,12 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->where(['embed._id' => ['$exists' => true]]),
         ];
 
+        // The 2-argument form on an embedded id keeps building an operator document.
+        yield 'where 2-arg embedded id with operator array keeps the operator document' => [
+            ['find' => [['embed._id' => ['$ne' => null]], []]],
+            fn (Builder $builder) => $builder->where('embed._id', ['$ne' => null]),
+        ];
+
         yield 'select colums with id alias' => [
             ['find' => [[], ['projection' => ['name' => 1, 'email' => 1, '_id' => 1]]]],
             fn (Builder $builder) => $builder->select('name', 'email', 'id'),

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -212,6 +212,31 @@ class QueryBuilderTest extends TestCase
         $this->assertNull($user);
     }
 
+    public function testFindRejectsOperatorId()
+    {
+        DB::table('users')->insert([['name' => 'Jane Doe'], ['name' => 'John Doe']]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value used as a document id or relation key cannot contain the MongoDB operator "$ne"');
+
+        DB::table('users')->find(['$ne' => null]);
+    }
+
+    public function testDeleteRejectsOperatorId()
+    {
+        DB::table('users')->insert([['name' => 'Jane Doe'], ['name' => 'John Doe']]);
+
+        try {
+            DB::table('users')->delete(['$ne' => null]);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('cannot contain the MongoDB operator "$ne"', $e->getMessage());
+        }
+
+        // No document was deleted by the injected operator.
+        $this->assertEquals(2, DB::table('users')->count());
+    }
+
     public function testCount()
     {
         DB::table('users')->insert([

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests;
 
 use Illuminate\Database\Eloquent\Collection;
+use InvalidArgumentException;
 use Mockery;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Tests\Models\Address;
@@ -476,6 +477,20 @@ class RelationsTest extends TestCase
         self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
     }
 
+    public function testBelongsToManyRejectsOperatorForeignKey(): void
+    {
+        $client = Client::create(['cclient_id' => (string) (new ObjectId()), 'years' => '5']);
+
+        // An operator document planted into the custom parent key (as request input
+        // parsed to a PHP array would be) must not resolve into an arbitrary document.
+        $client->cclient_id = ['$ne' => null];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('cannot contain the MongoDB operator "$ne"');
+
+        $client->skillsWithCustomKeys()->get();
+    }
+
     public function testBelongsToManyAttachEloquentCollectionWithCustomKeys(): void
     {
         $client = Client::create(['cclient_id' => (string) (new ObjectId()), 'years' => '5']);
@@ -680,6 +695,22 @@ class RelationsTest extends TestCase
         $this->assertInstanceOf(Client::class, $check->hasImageWithCustomOwnerKey);
     }
 
+    public function testMorphToRejectsOperatorForeignKey(): void
+    {
+        $user  = User::create(['name' => 'Secret User']);
+        $photo = Photo::create(['url' => 'http://example.com/p.jpg']);
+        $photo->hasImage()->associate($user)->save();
+
+        // An operator document planted into the raw morph foreign key (as request input
+        // parsed to a PHP array would be) must not resolve into an arbitrary document.
+        $photo->has_image_id = ['$ne' => null];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('cannot contain the MongoDB operator "$ne"');
+
+        $photo->hasImage()->first();
+    }
+
     public function testMorphToMany(): void
     {
         $user = User::query()->create(['name' => 'Young Gerald']);
@@ -830,6 +861,20 @@ class RelationsTest extends TestCase
         $this->assertEquals(1, $client->labelsWithCustomKeys->count());
         $this->assertContains($label->id, $client->labelsWithCustomKeys->pluck('id'));
         $this->assertNotContains($label2->id, $client->labelsWithCustomKeys->pluck('id'));
+    }
+
+    public function testMorphToManyRejectsOperatorForeignKey(): void
+    {
+        $client = Client::create(['cclient_id' => (string) (new ObjectId())]);
+
+        // An operator document planted into the embedded pivot-ids field must not
+        // resolve into an arbitrary document.
+        $client->clabel_ids = ['$ne' => null];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('cannot contain the MongoDB operator "$ne"');
+
+        $client->labelsWithCustomKeys()->get();
     }
 
     public function testMorphToManyLoadAndRefreshing(): void


### PR DESCRIPTION
A value that can only legitimately be a scalar document id or relation key was inserted into the MongoDB filter without validation, so an array value containing a dollar-prefixed key was executed as a live operator document instead of being treated as a value.

Such values are now rejected anywhere only a scalar id or relation key is valid. Plain arrays without operator keys are still accepted, so composite id values keep working. The guard is applied once where every _id and *_id value is normalized, and at the custom-key relation paths that bypass it.
