### PR TITLE
PHPLARA-260 Force literal equality when a 3-arg where('=') has an operator array

### DIFF
--- a/resources/boost/skills/laravel-mongodb/references/query-builder.md
+++ b/resources/boost/skills/laravel-mongodb/references/query-builder.md
@@ -122,6 +122,18 @@ Post::whereBetween('year', [2000, 2010])->get();
 Post::where('metadata.draft', true)->get();                // dotted path into sub-doc
 ```
 
+## `where()` and MQL injection
+
+With 1 or 2 arguments, an array value is read as a MongoDB operator document.
+Never pass unvalidated input there. The 3-argument form with `'='` always compares
+the value as a literal.
+
+```php
+Post::where('status', ['$ne' => 'draft'])->get();             // operator document
+Post::where('status', $request->input('status'))->get();      // DON'T DO THIS
+Post::where('status', '=', $request->input('status'))->get(); // safe: literal match
+```
+
 ## Raw aggregation entry point
 
 ```php

--- a/resources/boost/skills/laravel-mongodb/references/query-builder.md
+++ b/resources/boost/skills/laravel-mongodb/references/query-builder.md
@@ -122,11 +122,12 @@ Post::whereBetween('year', [2000, 2010])->get();
 Post::where('metadata.draft', true)->get();                // dotted path into sub-doc
 ```
 
-## `where()` and MQL injection
+## `where()` and MongoDB operator documents
 
 With 1 or 2 arguments, an array value is read as a MongoDB operator document.
-Never pass unvalidated input there. The 3-argument form with `'='` always compares
-the value as a literal.
+Never pass unvalidated input there. The 3-argument form with `'='` compares the
+value as a literal, and identifier columns (`_id`, `id`, `*._id`) reject operator
+arrays instead.
 
 ```php
 Post::where('status', ['$ne' => 'draft'])->get();             // operator document

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1270,6 +1270,15 @@ class Builder extends BaseBuilder
             if ($operator === self::UNSAFE_FIELD_QUERY) {
                 $operator = '=';
             } elseif ($operator === '=' && self::valueContainsOperator($params[2])) {
+                // Identifier columns only accept a scalar or a plain array (composite id).
+                // Reject an operator array here, and leave the non-id path to $eq below.
+                if (is_string($params[0]) && $this->isIdLikeField($params[0])) {
+                    throw new InvalidArgumentException(sprintf(
+                        'The value used as a document id or relation key cannot contain the MongoDB operator "%s".',
+                        self::firstOperatorKey($params[2]),
+                    ));
+                }
+
                 $params[2] = ['$eq' => $params[2]];
             }
         }
@@ -1321,6 +1330,43 @@ class Builder extends BaseBuilder
         }
 
         return false;
+    }
+
+    /**
+     * Whether a where column resolves to the MongoDB document id after the grammar
+     * aliasing: "id" becomes "_id", and "foo.id" becomes "foo._id" when configured.
+     * Operator arrays are rejected on such columns instead of being wrapped in $eq,
+     * so the rejection surfaces the offending operator.
+     */
+    private function isIdLikeField(string $column): bool
+    {
+        $key = array_key_first($this->grammar->prepareFieldsForQuery([$column => null]));
+
+        return $key === '_id' || str_ends_with($key, '._id');
+    }
+
+    /**
+     * The first "$"-prefixed key found in the value, depth-first, in the same order
+     * as the recursive rejection used for identifiers.
+     */
+    private static function firstOperatorKey(mixed $value): ?string
+    {
+        if (! is_array($value)) {
+            return null;
+        }
+
+        foreach ($value as $key => $item) {
+            if (is_string($key) && str_starts_with($key, '$')) {
+                return $key;
+            }
+
+            $operator = self::firstOperatorKey($item);
+            if ($operator !== null) {
+                return $operator;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -63,6 +63,7 @@ use function is_bool;
 use function is_callable;
 use function is_float;
 use function is_int;
+use function is_numeric;
 use function is_object;
 use function is_string;
 use function md5;
@@ -87,6 +88,12 @@ use function var_export;
 class Builder extends BaseBuilder
 {
     private const REGEX_DELIMITERS = ['/', '#', '~'];
+
+    /**
+     * Sentinel operator that is used instead of "=" that doesn't get converted
+     * to $eq when the value contains a MQL query operator.
+     */
+    private const UNSAFE_FIELD_QUERY = "\0unsafe-field-query";
 
     /**
      * The database collection.
@@ -1237,6 +1244,9 @@ class Builder extends BaseBuilder
      * If 2 arguments, the signature is: where(string $column, mixed $value)
      * If 3 arguments, the signature is: where(string $colum, string $operator, mixed $value)
      *
+     * With 1 or 2 arguments, an array value is read as a MongoDB operator document,
+     * so never pass unvalidated input there, it is open to MQL injection.
+     *
      * @param  Closure|string|array $column
      * @param  mixed                $operator
      * @param  mixed                $value
@@ -1256,6 +1266,12 @@ class Builder extends BaseBuilder
             if (is_string($operator) && str_starts_with($operator, '$')) {
                 $operator = substr($operator, 1);
             }
+
+            if ($operator === self::UNSAFE_FIELD_QUERY) {
+                $operator = '=';
+            } elseif ($operator === '=' && self::valueContainsOperator($params[2])) {
+                $params[2] = ['$eq' => $params[2]];
+            }
         }
 
         if (func_num_args() === 1 && ! is_array($column) && ! is_callable($column)) {
@@ -1267,6 +1283,44 @@ class Builder extends BaseBuilder
         }
 
         return parent::where(...$params);
+    }
+
+    /**
+     * The "=" operator of each generated call is an internal detail of the array
+     * shorthand, not an operator chosen by the caller: these calls must build an
+     * operator document like the 2-argument form does, not be hardened into $eq.
+     */
+    #[Override]
+    protected function addArrayOfWheres($column, $boolean, $method = 'where')
+    {
+        return $this->whereNested(function ($query) use ($column, $method, $boolean) {
+            foreach ($column as $key => $value) {
+                if (is_numeric($key) && is_array($value)) {
+                    $query->{$method}(...array_values($value), boolean: $boolean);
+                } else {
+                    $query->{$method}($key, self::UNSAFE_FIELD_QUERY, $value, $boolean);
+                }
+            }
+        }, $boolean);
+    }
+
+    private static function valueContainsOperator(mixed $value): bool
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $key => $item) {
+            if (is_string($key) && str_starts_with($key, '$')) {
+                return true;
+            }
+
+            if (self::valueContainsOperator($item)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -93,7 +93,7 @@ class Builder extends BaseBuilder
      * Sentinel operator that is used instead of "=" that doesn't get converted
      * to $eq when the value contains a MQL query operator.
      */
-    private const UNSAFE_FIELD_QUERY = "\0unsafe-field-query";
+    private const UNSAFE_FIELD_QUERY = 'unsafe-field-query';
 
     /**
      * The database collection.

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -221,6 +221,60 @@ class BuilderTest extends TestCase
                 ->orWhere('foo', '$type', 4),
         ];
 
+        yield 'where = with operator array is wrapped in $eq' => [
+            ['find' => [['token' => ['$eq' => ['$ne' => null]]], []]],
+            fn (Builder $builder) => $builder->where('token', '=', ['$ne' => null]),
+        ];
+
+        yield 'where _id = with operator array is wrapped in $eq' => [
+            ['find' => [['_id' => ['$eq' => ['$ne' => null]]], []]],
+            fn (Builder $builder) => $builder->where('_id', '=', ['$ne' => null]),
+        ];
+
+        yield 'where with 2-arg operator array is unchanged' => [
+            ['find' => [['token' => ['$ne' => null]], []]],
+            fn (Builder $builder) => $builder->where('token', ['$ne' => null]),
+        ];
+
+        yield 'where = with plain array is unchanged' => [
+            ['find' => [['tags' => ['a', 'b']], []]],
+            fn (Builder $builder) => $builder->where('tags', '=', ['a', 'b']),
+        ];
+
+        yield 'where = with nested operator is wrapped in $eq' => [
+            ['find' => [['meta' => ['$eq' => ['role' => ['$in' => ['admin']]]]], []]],
+            fn (Builder $builder) => $builder->where('meta', '=', ['role' => ['$in' => ['admin']]]),
+        ];
+
+        // The "=" that Laravel injects when expanding where(array) is not an operator
+        // chosen by the caller, so it must not be hardened into $eq.
+        yield 'where array shorthand with operator array is unchanged' => [
+            ['find' => [['tags' => ['$in' => ['a']]], []]],
+            fn (Builder $builder) => $builder->where(['tags' => ['$in' => ['a']]]),
+        ];
+
+        yield 'where array shorthand with $or is unchanged' => [
+            ['find' => [['$or' => [['a' => 1], ['b' => ['$ne' => null]]]], []]],
+            fn (Builder $builder) => $builder->where(['$or' => [['a' => 1], ['b' => ['$ne' => null]]]]),
+        ];
+
+        // Numeric keys hold [column, operator, value] tuples, where the operator is
+        // authored by the caller, so they keep the regular where() behaviour.
+        yield 'where array shorthand with operator tuples' => [
+            [
+                'find' => [
+                    [
+                        '$and' => [
+                            ['price' => ['$gt' => 100]],
+                            ['tag' => ['$all' => ['a', 'b']]],
+                        ],
+                    ],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder->where([['price', '>', 100], ['tag', 'all', ['a', 'b']]]),
+        ];
+
         /** @see DatabaseQueryBuilderTest::testBasicWhereNot() */
         yield 'whereNot (multiple)' => [
             [

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -226,9 +226,9 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->where('token', '=', ['$ne' => null]),
         ];
 
-        yield 'where _id = with operator array is wrapped in $eq' => [
-            ['find' => [['_id' => ['$eq' => ['$ne' => null]]], []]],
-            fn (Builder $builder) => $builder->where('_id', '=', ['$ne' => null]),
+        yield 'where _id = with plain composite array is not wrapped' => [
+            ['find' => [['_id' => ['tenant' => 1, 'seq' => 2]], []]],
+            fn (Builder $builder) => $builder->where('_id', '=', ['tenant' => 1, 'seq' => 2]),
         ];
 
         yield 'where with 2-arg operator array is unchanged' => [
@@ -1670,6 +1670,18 @@ class BuilderTest extends TestCase
             InvalidArgumentException::class,
             'First argument of MongoDB\Laravel\Query\Builder::where must be a field path as "string". Got "float"',
             fn (Builder $builder) => $builder->where(2.3, '>', 1),
+        ];
+
+        yield 'where _id = with operator array is rejected' => [
+            InvalidArgumentException::class,
+            'The value used as a document id or relation key cannot contain the MongoDB operator "$ne"',
+            fn (Builder $builder) => $builder->where('_id', '=', ['$ne' => null]),
+        ];
+
+        yield 'where _id = with nested operator array is rejected' => [
+            InvalidArgumentException::class,
+            'The value used as a document id or relation key cannot contain the MongoDB operator "$gt"',
+            fn (Builder $builder) => $builder->where('_id', '=', ['foo' => ['$gt' => 1]]),
         ];
     }
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -21,7 +21,6 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 use MongoDB\Driver\Cursor;
 use MongoDB\Driver\CursorInterface;
-use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
 use MongoDB\Driver\Monitoring\CommandSubscriber;
@@ -211,27 +210,6 @@ class QueryBuilderTest extends TestCase
     {
         $user = DB::table('users')->find(null);
         $this->assertNull($user);
-    }
-
-    public function testFindWithOperatorArrayMatchesNothing()
-    {
-        DB::table('users')->insert([['name' => 'Jane Doe'], ['name' => 'John Doe']]);
-
-        $this->assertNull(DB::table('users')->find(['$ne' => null]));
-    }
-
-    public function testDeleteWithOperatorArrayDeletesNothing()
-    {
-        DB::table('users')->insert([['name' => 'Jane Doe'], ['name' => 'John Doe']]);
-
-        // On the _id field the driver rejects the operator document outright, before the
-        // $eq literal comparison can run. Either way nothing is deleted.
-        try {
-            DB::table('users')->delete(['$ne' => null]);
-        } catch (BulkWriteException) {
-        }
-
-        $this->assertEquals(2, DB::table('users')->count());
     }
 
     public function testCount()

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -21,6 +21,7 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 use MongoDB\Driver\Cursor;
 use MongoDB\Driver\CursorInterface;
+use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
 use MongoDB\Driver\Monitoring\CommandSubscriber;
@@ -210,6 +211,27 @@ class QueryBuilderTest extends TestCase
     {
         $user = DB::table('users')->find(null);
         $this->assertNull($user);
+    }
+
+    public function testFindWithOperatorArrayMatchesNothing()
+    {
+        DB::table('users')->insert([['name' => 'Jane Doe'], ['name' => 'John Doe']]);
+
+        $this->assertNull(DB::table('users')->find(['$ne' => null]));
+    }
+
+    public function testDeleteWithOperatorArrayDeletesNothing()
+    {
+        DB::table('users')->insert([['name' => 'Jane Doe'], ['name' => 'John Doe']]);
+
+        // On the _id field the driver rejects the operator document outright, before the
+        // $eq literal comparison can run. Either way nothing is deleted.
+        try {
+            DB::table('users')->delete(['$ne' => null]);
+        } catch (BulkWriteException) {
+        }
+
+        $this->assertEquals(2, DB::table('users')->count());
     }
 
     public function testCount()


### PR DESCRIPTION
where($column, '=', $value) with an array value that contains a dollar-prefixed key embedded the array as-is, so the comparison was built from a live MongoDB operator document instead of a literal value.

For a regular field, such a value is now wrapped in an explicit $eq so it is compared as a literal document. On the _id field and the *_id fields, such a value is rejected, since only a scalar or a plain array (composite id) is valid there. Arrays without dollar-prefixed keys are left unchanged, so embedded documents and composite ids keep working.

Laravel expands where(array $conditions) into repeated where($column, '=', $value) calls. Those generated calls are marked with an internal sentinel operator so operator documents keep working in the array shorthand. The query builder skill now documents how each argument form treats array values.
